### PR TITLE
[codex] reduce TUI memory churn

### DIFF
--- a/docs/bugreports/tui-oom-investigation.md
+++ b/docs/bugreports/tui-oom-investigation.md
@@ -1,0 +1,152 @@
+# TUI OOM Investigation — 2026-04-06
+
+## Summary
+
+The original remote TUI problem was real, but it turned out to be a mix of two issues:
+
+1. A major artificial amplifier: the TUI was running React/Ink in development mode.
+2. Real application churn: session refreshes, selector work, and pane rendering were still heavier than they should be.
+
+After the fixes in this pass, the clean remote TUI no longer shows the old immediate runaway pattern in normal chat-only startup. On April 6, 2026, a clean chat-only run stabilized around `370-410 MB` RSS instead of the earlier `~60 MB/min` climb to OOM. That said, the app is still heavier than a text UI should be, and some interactions can still step RSS into the `~480-560 MB` range.
+
+## Original Problem
+
+`./run.sh remote` is a client-only TUI with no embedded workers. Before the fixes below:
+
+- long-running remote sessions could grow into multi-GB RSS
+- with `--max-old-space-size=512`, the TUI could OOM in roughly 12 minutes
+- the initial observed growth rate was about `60 MB/min` from startup
+
+## Environment
+
+- macOS ARM64
+- Node.js
+- ink `6.8.0`
+- remote mode: `PilotSwarmClient` + `PilotSwarmManagementClient` against remote PostgreSQL
+- no embedded workers in remote mode
+- `K8S_CONTEXT=toygres-aks` available, so log tailing can be enabled
+
+## Layered Probe Result
+
+The layered probe scripts were still useful and the high-level conclusion from them held:
+
+| Probe | What it runs | Result | Notes |
+|-------|-------------|--------|-------|
+| `L1` | SDK only | Stable | transport / pg not the primary leak |
+| `L2` | SDK + controller + store | Stable | controller polling alone did not reproduce the runaway |
+| `L3` | L2 + tiny Ink tree | Stable | minimal Ink rendering was fine |
+| `L5` | L2 + synthetic high dispatch, no rendering | Stable | dispatch frequency alone was not enough |
+| `L6` | L3 + high dispatch | Borderline | small tree could absorb pressure |
+| Real TUI | full component tree | Problematic | full render path was where the memory pressure surfaced |
+
+The important conclusion remained: the main issue was in the interaction between the full React/Ink render tree and continuous state updates, not in the raw remote SDK layer.
+
+## What We Found
+
+### 1. React development mode was a major amplifier
+
+A live heap snapshot showed huge numbers of React development profiling artifacts, including `PerformanceMeasure` objects and React dev-only user timing strings. That pointed directly at the TUI loading the development build of React / react-reconciler.
+
+This was confirmed by the launch path:
+
+- `NODE_ENV` was not set
+- the CLI entrypoint loaded React before forcing production mode
+
+### 2. The app also had real avoidable churn
+
+There were several cases where the UI tree was doing work even when nothing materially changed:
+
+- `sessions/loaded` and detail merges were replacing session objects on no-op refreshes
+- the store notified every subscriber even when the reducer returned the same state object
+- startup hydration eagerly loaded more history than needed for the default inspector path
+- inactive inspector tabs were still subscribing to heavy state like all histories, logs, and execution history
+- chat title chrome depended on larger session/history structures than necessary
+
+### 3. The current residual issue is interaction-sensitive, not a universal immediate runaway
+
+After the fixes below, clean runs looked materially better:
+
+- April 6, 2026 at `1:56:37 PM` through `1:58:28 PM` Pacific time: chat-only run held at `368-369 MB` RSS
+- April 6, 2026 at `2:13:29 PM` through `2:14:40 PM` Pacific time: another fresh chat-only run held at `396-397 MB` RSS
+
+Clean tab switches were also much better than the original failure mode:
+
+- opening execution history from an already-heavier state added only about `+3 MB`
+- switching to node map from a similar state added about `+10-20 MB`
+
+The remaining heavier cases were more tied to broad interaction:
+
+- scrolling the session list produced a step from about `370 MB` to about `478 MB`
+- mixed/random interaction could step a clean run from roughly `410 MB` into the high `400s`
+
+That means the current state is no longer “always runaway from startup,” but it is still “too heavy under interaction.”
+
+## Fixes Kept
+
+These changes are worth keeping:
+
+1. Force production React for the TUI launch path.
+   - `packages/cli/bin/tui.js`
+   - `run.sh`
+
+2. Remove no-op session churn and same-state subscriber notifications.
+   - `packages/ui-core/src/controller.js`
+   - `packages/ui-core/src/reducer.js`
+   - `packages/ui-core/src/store.js`
+
+3. Reduce startup eager history loading for the sequence inspector path.
+   - `packages/ui-core/src/controller.js`
+
+4. Reduce inactive pane refresh costs.
+   - `packages/ui-react/src/components.js`
+   - `packages/ui-core/src/selectors.js`
+
+5. Add an in-TUI RSS readout to the sessions pane header for live debugging.
+   - `packages/ui-react/src/components.js`
+   - `packages/cli/src/platform.js`
+
+## Current Conclusion
+
+As of April 6, 2026:
+
+- the original dev-mode amplifier is fixed
+- the TUI no longer immediately reproduces the old startup runaway in clean chat-only runs
+- the remaining memory problem looks more like expensive interaction-driven render/state churn than one single retained giant object
+- the sessions pane / session tree path still deserves more attention than history or node map based on observed step-ups
+
+## Remaining Work
+
+The next likely targets are:
+
+- session list rendering and session-tree selectors
+- descendant-count / collapse-badge computation on session movement
+- expensive line-model generation that still recreates large arrays during broad UI interaction
+- any remaining places where selector inputs are wider than the visible pane actually needs
+
+## Reusable Probe Scripts
+
+These layered probes in `scripts/tmp/` still look useful enough to keep for future regression checks:
+
+| Script | Purpose |
+|--------|---------|
+| `mem-leak-probe.mjs` | SDK-only baseline |
+| `mem-leak-probe-L2.mjs` | controller + store baseline |
+| `mem-leak-probe-L3.mjs` | minimal Ink render baseline |
+| `mem-leak-probe-L4.mjs` | additional incremental render probe |
+| `mem-leak-probe-L5.mjs` | high-frequency dispatch without rendering |
+| `mem-leak-probe-L6.mjs` | small Ink tree under higher churn |
+
+External watcher used during the investigation:
+
+- `/tmp/tui-memwatch-clean.sh`
+- log file: `/tmp/tui-memwatch-clean.log`
+
+## Cleanup
+
+The following ad hoc, one-off heap-inspector helpers were removed from the repo after use:
+
+- `scripts/tmp/inspector-heap-sampling.mjs`
+- `scripts/tmp/inspector-heap-snapshot.mjs`
+- `scripts/tmp/analyze-heap-snapshot.mjs`
+
+Those were useful for this debugging pass, but they were temporary live-process helpers rather than repo-level tools we expect to maintain.

--- a/packages/cli/bin/tui.js
+++ b/packages/cli/bin/tui.js
@@ -1,7 +1,10 @@
 #!/usr/bin/env node
 
-import { parseCliIntoEnv } from "../src/bootstrap-env.js";
-import { startTuiApp } from "../src/index.js";
+// Force the shipped TUI onto production React/Ink unless the caller
+// explicitly opts into another environment for debugging.
+process.env.NODE_ENV ??= "production";
 
+const { parseCliIntoEnv } = await import("../src/bootstrap-env.js");
 const config = parseCliIntoEnv(process.argv.slice(2));
+const { startTuiApp } = await import("../src/index.js");
 await startTuiApp(config);

--- a/packages/cli/src/node-sdk-transport.js
+++ b/packages/cli/src/node-sdk-transport.js
@@ -575,10 +575,19 @@ export class NodeSdkTransport {
     }
 
     emitLogEntry(entry) {
-        for (const handler of this.logSubscribers) {
-            try {
-                handler(entry);
-            } catch {}
+        if (!this._logBatch) this._logBatch = [];
+        this._logBatch.push(entry);
+        if (!this._logBatchTimer) {
+            this._logBatchTimer = setTimeout(() => {
+                const batch = this._logBatch;
+                this._logBatch = [];
+                this._logBatchTimer = null;
+                for (const handler of this.logSubscribers) {
+                    try {
+                        handler(batch);
+                    } catch {}
+                }
+            }, 250);
         }
     }
 
@@ -690,6 +699,11 @@ export class NodeSdkTransport {
     }
 
     async stopLogTail() {
+        if (this._logBatchTimer) {
+            clearTimeout(this._logBatchTimer);
+            this._logBatchTimer = null;
+            this._logBatch = [];
+        }
         if (this.logRestartTimer) {
             clearTimeout(this.logRestartTimer);
             this.logRestartTimer = null;

--- a/packages/cli/src/platform.js
+++ b/packages/cli/src/platform.js
@@ -365,15 +365,39 @@ function renderPanelRow(line, rowKey, contentWidth, borderColor, scrollIndicator
         React.createElement(Text, { color: resolveColorToken(borderColor) }, "│"));
 }
 
-function renderBorderTop(title, color, width) {
+function renderBorderTop(title, color, width, titleRight = null) {
     const safeWidth = Math.max(8, Number(width) || 40);
-    const safeTitleRuns = trimRuns(normalizeTitleRuns(title, color), Math.max(1, safeWidth - 6));
-    const fill = Math.max(0, safeWidth - titleRunLength(safeTitleRuns) - 5);
+    const normalizedTitleRuns = normalizeTitleRuns(title, color);
+    const normalizedRightRuns = titleRight ? normalizeTitleRuns(titleRight, "gray") : [];
+    let safeTitleRuns = trimRuns(normalizedTitleRuns, Math.max(1, safeWidth - 6));
+    let safeRightRuns = trimRuns(normalizedRightRuns, Math.max(0, safeWidth - 8));
+    let titleWidth = titleRunLength(safeTitleRuns);
+    let rightWidth = titleRunLength(safeRightRuns);
+    const hasRightTitle = rightWidth > 0;
+    const chromeWidth = hasRightTitle ? 6 : 5;
+    const availableTitleWidth = Math.max(1, safeWidth - chromeWidth);
+
+    if (titleWidth + rightWidth > availableTitleWidth) {
+        safeTitleRuns = trimRuns(normalizedTitleRuns, Math.max(1, availableTitleWidth - rightWidth));
+        titleWidth = titleRunLength(safeTitleRuns);
+        if (titleWidth + rightWidth > availableTitleWidth) {
+            safeRightRuns = trimRuns(normalizedRightRuns, Math.max(0, availableTitleWidth - titleWidth));
+            rightWidth = titleRunLength(safeRightRuns);
+        }
+    }
+
+    const fill = Math.max(0, safeWidth - titleWidth - rightWidth - chromeWidth);
 
     return React.createElement(Box, null,
         React.createElement(Text, { color: resolveColorToken(color) }, "╭─ "),
         renderInlineRuns(safeTitleRuns, "title"),
-        React.createElement(Text, { color: resolveColorToken(color) }, ` ${"─".repeat(fill)}╮`));
+        hasRightTitle
+            ? [
+                React.createElement(Text, { key: "title-fill", color: resolveColorToken(color) }, ` ${"─".repeat(fill)} `),
+                ...renderInlineRuns(safeRightRuns, "title-right"),
+                React.createElement(Text, { key: "title-end", color: resolveColorToken(color) }, "╮"),
+            ]
+            : React.createElement(Text, { color: resolveColorToken(color) }, ` ${"─".repeat(fill)}╮`));
 }
 
 function renderBorderBottom(color, width) {
@@ -581,6 +605,7 @@ function Header({ title, subtitle }) {
 
 function Panel({
     title,
+    titleRight,
     color = "white",
     focused = false,
     width,
@@ -649,7 +674,7 @@ function Panel({
         flexGrow,
         flexBasis,
     },
-    renderBorderTop(title, borderColor, safeWidth),
+    renderBorderTop(title, borderColor, safeWidth, titleRight),
     lines
         ? React.createElement(Box, { flexDirection: "column", flexGrow: 1, backgroundColor: fillColor || undefined },
             [

--- a/packages/ui-core/src/controller.js
+++ b/packages/ui-core/src/controller.js
@@ -80,31 +80,64 @@ function extractSessionContextUsageFromEvents(initialContextUsage, events = []) 
     return current;
 }
 
+function areStructuredValuesEqual(left, right) {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+        for (let index = 0; index < left.length; index += 1) {
+            if (!areStructuredValuesEqual(left[index], right[index])) return false;
+        }
+        return true;
+    }
+    if (!left || !right || typeof left !== "object" || typeof right !== "object") {
+        return false;
+    }
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) return false;
+    for (const key of leftKeys) {
+        if (!Object.prototype.hasOwnProperty.call(right, key)) return false;
+        if (!areStructuredValuesEqual(left[key], right[key])) return false;
+    }
+    return true;
+}
+
 function buildSessionMergePatch(previousSession, nextSession) {
     if (!nextSession?.sessionId) return null;
 
     const patch = { sessionId: nextSession.sessionId };
+    let changed = false;
     for (const [key, value] of Object.entries(nextSession)) {
         if (key === "sessionId" || value === undefined) continue;
+        if (areStructuredValuesEqual(previousSession?.[key], value)) continue;
         patch[key] = value;
+        changed = true;
     }
 
     if (nextSession.pendingQuestion === undefined && previousSession?.pendingQuestion && nextSession.status !== "input_required") {
         patch.pendingQuestion = null;
+        changed = true;
     }
     if (nextSession.waitReason === undefined && previousSession?.waitReason && nextSession.status !== "waiting" && nextSession.status !== "input_required") {
         patch.waitReason = null;
+        changed = true;
     }
     if (nextSession.error === undefined && previousSession?.error && nextSession.status !== "failed" && nextSession.status !== "error") {
         patch.error = null;
+        changed = true;
     }
     if (nextSession.result === undefined && previousSession?.result && nextSession.status !== "completed") {
         patch.result = null;
+        changed = true;
     }
     if (nextSession.cronActive !== true) {
-        if (previousSession?.cronReason) patch.cronReason = null;
+        if (previousSession?.cronReason) {
+            patch.cronReason = null;
+            changed = true;
+        }
         if (previousSession?.cronInterval != null && nextSession.cronInterval === undefined) {
             patch.cronInterval = null;
+            changed = true;
         }
     }
 
@@ -117,9 +150,10 @@ function buildSessionMergePatch(previousSession, nextSession) {
         const nextContextUsage = { ...previousSession.contextUsage };
         delete nextContextUsage.compaction;
         patch.contextUsage = Object.keys(nextContextUsage).length > 0 ? nextContextUsage : null;
+        changed = true;
     }
 
-    return patch;
+    return changed ? patch : null;
 }
 
 function isTerminalOrchestrationStatus(status) {
@@ -726,16 +760,17 @@ export class PilotSwarmUiController {
     }
 
     async ensureInspectorData(targetTab = this.getState().ui.inspectorTab) {
-        if (targetTab === "nodes" || targetTab === "sequence") {
+        if (targetTab === "sequence") {
+            const activeSessionId = this.getState().sessions.activeSessionId;
+            if (!activeSessionId) return;
+            await this.ensureSessionHistory(activeSessionId).catch(() => {});
+            await this.ensureOrchestrationStats(activeSessionId).catch(() => {});
+            return;
+        }
+        if (targetTab === "nodes") {
             const sessionIds = Object.keys(this.getState().sessions.byId);
             if (sessionIds.length === 0) return;
             await Promise.allSettled(sessionIds.map((sessionId) => this.ensureSessionHistory(sessionId)));
-            if (targetTab === "sequence") {
-                const activeSessionId = this.getState().sessions.activeSessionId;
-                if (activeSessionId) {
-                    await this.ensureOrchestrationStats(activeSessionId).catch(() => {});
-                }
-            }
             return;
         }
         if (targetTab === "files") {
@@ -2081,8 +2116,11 @@ export class PilotSwarmUiController {
             return;
         }
 
-        this.logUnsubscribe = this.transport.startLogTail((entry) => {
-            this.dispatch({ type: "logs/append", entry });
+        this.logUnsubscribe = this.transport.startLogTail((entryOrBatch) => {
+            const entries = Array.isArray(entryOrBatch) ? entryOrBatch : [entryOrBatch];
+            if (entries.length > 0) {
+                this.dispatch({ type: "logs/append", entries });
+            }
         });
         this.dispatch({ type: "logs/tailing", tailing: true });
         this.dispatch({ type: "ui/status", text: "Log tailing started" });

--- a/packages/ui-core/src/reducer.js
+++ b/packages/ui-core/src/reducer.js
@@ -38,10 +38,36 @@ function clampHistoryItems(items, maxItems) {
     return list.length > safeMax ? list.slice(-safeMax) : list;
 }
 
+function areStructuredValuesEqual(left, right) {
+    if (Object.is(left, right)) return true;
+    if (Array.isArray(left) || Array.isArray(right)) {
+        if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false;
+        for (let index = 0; index < left.length; index += 1) {
+            if (!areStructuredValuesEqual(left[index], right[index])) return false;
+        }
+        return true;
+    }
+    if (!left || !right || typeof left !== "object" || typeof right !== "object") {
+        return false;
+    }
+    const leftKeys = Object.keys(left);
+    const rightKeys = Object.keys(right);
+    if (leftKeys.length !== rightKeys.length) return false;
+    for (const key of leftKeys) {
+        if (!Object.prototype.hasOwnProperty.call(right, key)) return false;
+        if (!areStructuredValuesEqual(left[key], right[key])) return false;
+    }
+    return true;
+}
+
 function mergeDefinedSessionFields(previousSession = {}, nextSession = {}) {
-    const merged = { ...previousSession };
+    let merged = previousSession || {};
     for (const [key, value] of Object.entries(nextSession || {})) {
         if (value === undefined) continue;
+        if (areStructuredValuesEqual(previousSession?.[key], value)) continue;
+        if (merged === previousSession) {
+            merged = { ...(previousSession || {}) };
+        }
         merged[key] = value;
     }
     return merged;
@@ -256,11 +282,12 @@ export function appReducer(state, action) {
 
         case "sessions/loaded": {
             const byId = {};
+            let anyChanged = false;
             for (const session of action.sessions) {
-                byId[session.sessionId] = mergeDefinedSessionFields(
-                    state.sessions.byId[session.sessionId] || {},
-                    session,
-                );
+                const previous = state.sessions.byId[session.sessionId];
+                const merged = mergeDefinedSessionFields(previous, session);
+                byId[session.sessionId] = merged;
+                if (!anyChanged && merged !== previous) anyChanged = true;
             }
             if (
                 state.sessions.activeSessionId
@@ -270,7 +297,18 @@ export function appReducer(state, action) {
                 byId[state.sessions.activeSessionId] = {
                     ...state.sessions.byId[state.sessions.activeSessionId],
                 };
+                anyChanged = true;
             }
+            // Check if session set changed (added/removed)
+            const prevIds = Object.keys(state.sessions.byId);
+            const nextIds = Object.keys(byId);
+            if (prevIds.length !== nextIds.length) anyChanged = true;
+            if (!anyChanged) {
+                for (const id of nextIds) {
+                    if (!state.sessions.byId[id]) { anyChanged = true; break; }
+                }
+            }
+            if (!anyChanged) return state;
             const mergedSessions = Object.values(byId);
             const {
                 orderById,
@@ -298,12 +336,12 @@ export function appReducer(state, action) {
 
         case "sessions/merged": {
             if (!action.session?.sessionId) return state;
+            const previousSession = state.sessions.byId[action.session.sessionId];
+            const mergedSession = mergeDefinedSessionFields(previousSession, action.session);
+            if (mergedSession === previousSession) return state;
             const byId = {
                 ...state.sessions.byId,
-                [action.session.sessionId]: {
-                    ...(state.sessions.byId[action.session.sessionId] || {}),
-                    ...action.session,
-                },
+                [action.session.sessionId]: mergedSession,
             };
             const {
                 orderById,
@@ -822,17 +860,19 @@ export function appReducer(state, action) {
                 },
             };
 
-        case "logs/append":
+        case "logs/append": {
+            const newEntries = (Array.isArray(action.entries) ? action.entries : [action.entry]).filter(Boolean);
+            if (newEntries.length === 0) return state;
+            const combined = [...(state.logs.entries || []), ...newEntries];
+            const capped = combined.length > 1000 ? combined.slice(-1000) : combined;
             return {
                 ...state,
                 logs: {
                     ...state.logs,
-                    entries: normalizeLogEntries([
-                        ...(state.logs.entries || []),
-                        ...(Array.isArray(action.entries) ? action.entries : [action.entry]).filter(Boolean),
-                    ]),
+                    entries: capped,
                 },
             };
+        }
 
         default:
             return state;

--- a/packages/ui-core/src/selectors.js
+++ b/packages/ui-core/src/selectors.js
@@ -726,7 +726,6 @@ export function selectChatPaneChrome(state) {
     const session = selectActiveSession(state);
     const totalDescendantCounts = getTotalDescendantCounts(state.sessions.byId);
     const visibleDescendantCounts = getVisibleDescendantCounts(state.sessions.flat, state.sessions.byId);
-    const inspectorWindow = getRecentActivityWindow(state);
 
     if (!session) {
         return {
@@ -769,7 +768,7 @@ export function selectChatPaneChrome(state) {
     }
 
     if (state.ui.inspectorTab === "sequence" || state.ui.inspectorTab === "nodes") {
-        title.push({ text: ` [${inspectorWindow.label} window]`, color: "gray" });
+        title.push({ text: " [last 5m window]", color: "gray" });
     }
 
     return {
@@ -1376,6 +1375,7 @@ function shortNodeLabel(nodeId) {
 }
 
 const RECENT_ACTIVITY_WINDOW_MS = 5 * 60 * 1000;
+const RECENT_ACTIVITY_WINDOW_LABEL = "last 5m";
 
 function getRecentActivityWindow(state) {
     let endMs = 0;
@@ -1398,7 +1398,7 @@ function getRecentActivityWindow(state) {
     return {
         startMs: endMs - RECENT_ACTIVITY_WINDOW_MS,
         endMs,
-        label: "last 5m",
+        label: RECENT_ACTIVITY_WINDOW_LABEL,
     };
 }
 
@@ -2468,7 +2468,9 @@ export function selectInspector(state, options = {}) {
     const maxWidth = Math.max(18, Number(options?.width) || 36);
     const allowWideColumns = Boolean(options?.allowWideColumns);
     const shortId = session ? shortSessionId(session.sessionId) : "";
-    const recentWindow = getRecentActivityWindow(state);
+    const recentWindow = activeTab === "sequence" || activeTab === "nodes"
+        ? getRecentActivityWindow(state)
+        : null;
     const title = activeTab === "nodes"
         ? [
             { text: "Node Map", color: "magenta", bold: true },

--- a/packages/ui-core/src/store.js
+++ b/packages/ui-core/src/store.js
@@ -7,7 +7,11 @@ export function createStore(reducer, initialState) {
             return state;
         },
         dispatch(action) {
-            state = reducer(state, action);
+            const nextState = reducer(state, action);
+            if (Object.is(nextState, state)) {
+                return action;
+            }
+            state = nextState;
             for (const listener of listeners) listener(state, action);
             return action;
         },

--- a/packages/ui-react/src/components.js
+++ b/packages/ui-react/src/components.js
@@ -41,6 +41,108 @@ function shallowEqualObject(left, right) {
     return true;
 }
 
+function shallowEqualArray(left, right, itemEqual = Object.is) {
+    if (Object.is(left, right)) return true;
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    for (let index = 0; index < left.length; index += 1) {
+        if (!itemEqual(left[index], right[index])) return false;
+    }
+    return true;
+}
+
+function shallowEqualChatChrome(left, right) {
+    if (Object.is(left, right)) return true;
+    if (!left || !right) return false;
+    return Object.is(left.color, right.color)
+        && shallowEqualArray(left.title, right.title, shallowEqualObject);
+}
+
+function readProcessRssBytes() {
+    try {
+        const runtimeProcess = globalThis?.process;
+        const memoryUsage = runtimeProcess?.memoryUsage;
+        if (typeof memoryUsage?.rss === "function") {
+            const rss = Number(memoryUsage.rss());
+            return Number.isFinite(rss) && rss > 0 ? rss : null;
+        }
+        if (typeof memoryUsage === "function") {
+            const rss = Number(memoryUsage.call(runtimeProcess)?.rss);
+            return Number.isFinite(rss) && rss > 0 ? rss : null;
+        }
+    } catch {}
+    return null;
+}
+
+function formatProcessRssTitleRuns(rssBytes) {
+    if (!Number.isFinite(rssBytes) || rssBytes <= 0) return null;
+    const rssMb = Math.round(rssBytes / (1024 * 1024));
+    return [
+        { text: "rss ", color: "gray" },
+        { text: `${rssMb}M`, color: "white", bold: true },
+    ];
+}
+
+function useProcessRssTitleRuns(sampleIntervalMs = 2000) {
+    const [rssBytes, setRssBytes] = React.useState(() => readProcessRssBytes());
+
+    React.useEffect(() => {
+        if (readProcessRssBytes() == null) return undefined;
+        const update = () => {
+            const nextRssBytes = readProcessRssBytes();
+            if (nextRssBytes == null) return;
+            setRssBytes((currentRssBytes) => (currentRssBytes === nextRssBytes ? currentRssBytes : nextRssBytes));
+        };
+        update();
+        const timer = setInterval(update, sampleIntervalMs);
+        return () => clearInterval(timer);
+    }, [sampleIntervalMs]);
+
+    return React.useMemo(() => formatProcessRssTitleRuns(rssBytes), [rssBytes]);
+}
+
+function buildSingleSessionMap(sessionId, session) {
+    return sessionId && session ? { [sessionId]: session } : {};
+}
+
+function normalizeInspectorLine(line) {
+    return typeof line === "string"
+        ? { text: line, color: "white" }
+        : line;
+}
+
+function renderInspectorPanel(platform, inspector, meta, width, height, frame) {
+    const tabLine = (inspector.tabs || INSPECTOR_TABS).map((tab) => ({
+        text: tab === inspector.activeTab ? `[${tab}] ` : `${tab} `,
+        color: tab === inspector.activeTab ? "magenta" : "gray",
+        bold: tab === inspector.activeTab,
+    }));
+    const normalizedLines = (inspector.lines || []).map(normalizeInspectorLine);
+    const normalizedStickyLines = (inspector.stickyLines || []).map(normalizeInspectorLine);
+    const stickyLines = inspector.activeTab === "sequence"
+        ? [tabLine, ...normalizedStickyLines]
+        : [];
+    const lines = inspector.activeTab === "sequence"
+        ? normalizedLines
+        : [tabLine, ...normalizedLines];
+
+    return React.createElement(platform.Panel, {
+        title: inspector.title,
+        color: "magenta",
+        focused: meta.focused,
+        width,
+        height,
+        stickyLines,
+        marginBottom: PANE_GAP_Y,
+        lines,
+        scrollOffset: meta.inspectorScroll,
+        scrollMode: inspector.activeTab === "logs" || inspector.activeTab === "sequence" ? "bottom" : "top",
+        paneId: "inspector",
+        paneLabel: inspector.activeTab === "sequence" ? "Sequence" : "Inspector",
+        frame,
+    });
+}
+
 function fitText(value, maxWidth) {
     const text = String(value || "");
     if (maxWidth <= 0) return "";
@@ -89,6 +191,7 @@ function buildWorkspacePaneFrames(layout) {
 
 const SessionList = React.memo(function SessionList({ controller, maxRows, width, height, frame }) {
     const platform = useUiPlatform();
+    const rssTitleRuns = useProcessRssTitleRuns();
     const sessionView = useControllerSelector(controller, (state) => ({
         sessions: state.sessions,
         mode: state.connection?.mode || "local",
@@ -114,6 +217,7 @@ const SessionList = React.memo(function SessionList({ controller, maxRows, width
 
     return React.createElement(platform.Panel, {
         title: "Sessions",
+        titleRight: rssTitleRuns,
         color: "yellow",
         focused: sessionView.focused,
         width,
@@ -128,18 +232,16 @@ const SessionList = React.memo(function SessionList({ controller, maxRows, width
 
 const ChatPane = React.memo(function ChatPane({ controller, width, height, frame }) {
     const platform = useUiPlatform();
+    const chrome = useControllerSelector(controller, selectChatPaneChrome, shallowEqualChatChrome);
     const chatView = useControllerSelector(controller, (state) => {
         const activeSessionId = state.sessions.activeSessionId;
         return {
-            sessionsById: state.sessions.byId,
-            sessionsFlat: state.sessions.flat,
             activeSessionId,
             activeSession: activeSessionId ? state.sessions.byId[activeSessionId] || null : null,
             activeHistory: activeSessionId ? state.history.bySessionId.get(activeSessionId) || null : null,
             branding: state.branding,
             connectionError: state.connection.error,
             connectionMode: state.connection.mode,
-            inspectorTab: state.ui.inspectorTab,
             chatScroll: state.ui.scroll.chat,
             focused: state.ui.focusRegion === "chat",
         };
@@ -158,28 +260,21 @@ const ChatPane = React.memo(function ChatPane({ controller, width, height, frame
             },
             sessions: {
                 activeSessionId: chatView.activeSessionId,
-                byId: chatView.sessionsById,
-                flat: chatView.sessionsFlat,
+                byId: buildSingleSessionMap(chatView.activeSessionId, chatView.activeSession),
             },
             history: {
                 bySessionId: historyMap,
-            },
-            ui: {
-                inspectorTab: chatView.inspectorTab,
             },
         };
     }, [
         chatView.activeHistory,
         chatView.activeSessionId,
+        chatView.activeSession,
         chatView.branding,
         chatView.connectionError,
         chatView.connectionMode,
-        chatView.inspectorTab,
-        chatView.sessionsById,
-        chatView.sessionsFlat,
     ]);
     const startupError = !chatView.activeSessionId && chatView.connectionError;
-    const chrome = React.useMemo(() => selectChatPaneChrome(selectorState), [selectorState]);
     const elements = React.useMemo(() => (startupError
         ? [
             { kind: "markup", value: chatView.branding.splash },
@@ -322,50 +417,140 @@ const FilesBrowser = React.memo(function FilesBrowser({ controller, width, heigh
     ));
 });
 
-const InspectorPane = React.memo(function InspectorPane({ controller, width, height, frame }) {
+const InspectorSequencePane = React.memo(function InspectorSequencePane({ controller, width, height, frame, meta }) {
     const platform = useUiPlatform();
-    const inspectorMeta = useControllerSelector(controller, (state) => ({
-        inspectorTab: state.ui.inspectorTab,
-        inspectorScroll: state.ui.scroll.inspector,
-        focused: state.ui.focusRegion === "inspector",
-    }), shallowEqualObject);
     const contentWidth = Math.max(20, width - 4);
-    const inspectorState = useControllerSelector(controller, (state) => ({
-        branding: state.branding,
+    const sequenceState = useControllerSelector(controller, (state) => ({
         activeSessionId: state.sessions.activeSessionId,
         activeSession: state.sessions.activeSessionId ? state.sessions.byId[state.sessions.activeSessionId] || null : null,
         activeOrchestration: state.sessions.activeSessionId
             ? state.orchestration.bySessionId?.[state.sessions.activeSessionId] || null
             : null,
-        sessionsById: state.sessions.byId,
-        sessionsFlat: state.sessions.flat,
         histories: state.history.bySessionId,
+    }), shallowEqualObject);
+    const selectorState = React.useMemo(() => ({
+        sessions: {
+            activeSessionId: sequenceState.activeSessionId,
+            byId: buildSingleSessionMap(sequenceState.activeSessionId, sequenceState.activeSession),
+        },
+        history: {
+            bySessionId: sequenceState.histories,
+        },
+        orchestration: {
+            bySessionId: sequenceState.activeSessionId && sequenceState.activeOrchestration
+                ? { [sequenceState.activeSessionId]: sequenceState.activeOrchestration }
+                : {},
+        },
+        ui: {
+            inspectorTab: "sequence",
+        },
+    }), [
+        sequenceState.activeOrchestration,
+        sequenceState.activeSession,
+        sequenceState.activeSessionId,
+        sequenceState.histories,
+    ]);
+    const inspector = React.useMemo(
+        () => selectInspector(selectorState, { width: contentWidth }),
+        [contentWidth, selectorState],
+    );
+
+    return renderInspectorPanel(platform, inspector, meta, width, height, frame);
+});
+
+const InspectorLogsPane = React.memo(function InspectorLogsPane({ controller, width, height, frame, meta }) {
+    const platform = useUiPlatform();
+    const contentWidth = Math.max(20, width - 4);
+    const logsState = useControllerSelector(controller, (state) => ({
+        activeSessionId: state.sessions.activeSessionId,
+        activeSession: state.sessions.activeSessionId ? state.sessions.byId[state.sessions.activeSessionId] || null : null,
         logs: state.logs,
-        inspectorTab: state.ui.inspectorTab,
+    }), shallowEqualObject);
+    const selectorState = React.useMemo(() => ({
+        sessions: {
+            activeSessionId: logsState.activeSessionId,
+            byId: buildSingleSessionMap(logsState.activeSessionId, logsState.activeSession),
+        },
+        logs: logsState.logs,
+        ui: {
+            inspectorTab: "logs",
+        },
+    }), [logsState.activeSession, logsState.activeSessionId, logsState.logs]);
+    const inspector = React.useMemo(
+        () => selectInspector(selectorState, { width: contentWidth }),
+        [contentWidth, selectorState],
+    );
+
+    return renderInspectorPanel(platform, inspector, meta, width, height, frame);
+});
+
+const InspectorHistoryPane = React.memo(function InspectorHistoryPane({ controller, width, height, frame, meta }) {
+    const platform = useUiPlatform();
+    const contentWidth = Math.max(20, width - 4);
+    const historyState = useControllerSelector(controller, (state) => ({
+        activeSessionId: state.sessions.activeSessionId,
+        activeSession: state.sessions.activeSessionId ? state.sessions.byId[state.sessions.activeSessionId] || null : null,
         executionHistory: state.executionHistory,
     }), shallowEqualObject);
     const selectorState = React.useMemo(() => ({
-        branding: inspectorState.branding,
         sessions: {
-            activeSessionId: inspectorState.activeSessionId,
-            byId: inspectorState.sessionsById,
-            flat: inspectorState.sessionsFlat,
+            activeSessionId: historyState.activeSessionId,
+            byId: buildSingleSessionMap(historyState.activeSessionId, historyState.activeSession),
+        },
+        executionHistory: historyState.executionHistory,
+        ui: {
+            inspectorTab: "history",
+        },
+    }), [historyState.activeSession, historyState.activeSessionId, historyState.executionHistory]);
+    const inspector = React.useMemo(
+        () => selectInspector(selectorState, { width: contentWidth }),
+        [contentWidth, selectorState],
+    );
+
+    return renderInspectorPanel(platform, inspector, meta, width, height, frame);
+});
+
+const InspectorNodesPane = React.memo(function InspectorNodesPane({ controller, width, height, frame, meta }) {
+    const platform = useUiPlatform();
+    const contentWidth = Math.max(20, width - 4);
+    const nodesState = useControllerSelector(controller, (state) => ({
+        activeSessionId: state.sessions.activeSessionId,
+        sessionsById: state.sessions.byId,
+        sessionsFlat: state.sessions.flat,
+        histories: state.history.bySessionId,
+    }), shallowEqualObject);
+    const selectorState = React.useMemo(() => ({
+        sessions: {
+            activeSessionId: nodesState.activeSessionId,
+            byId: nodesState.sessionsById,
+            flat: nodesState.sessionsFlat,
         },
         history: {
-            bySessionId: inspectorState.histories,
+            bySessionId: nodesState.histories,
         },
-        orchestration: {
-            bySessionId: inspectorState.activeSessionId && inspectorState.activeOrchestration
-                ? { [inspectorState.activeSessionId]: inspectorState.activeOrchestration }
-                : {},
-        },
-        logs: inspectorState.logs,
         ui: {
-            inspectorTab: inspectorState.inspectorTab,
+            inspectorTab: "nodes",
         },
-        executionHistory: inspectorState.executionHistory,
-    }), [inspectorState]);
-    const inspector = React.useMemo(() => selectInspector(selectorState, { width: contentWidth }), [contentWidth, selectorState]);
+    }), [
+        nodesState.activeSessionId,
+        nodesState.histories,
+        nodesState.sessionsById,
+        nodesState.sessionsFlat,
+    ]);
+    const inspector = React.useMemo(
+        () => selectInspector(selectorState, { width: contentWidth }),
+        [contentWidth, selectorState],
+    );
+
+    return renderInspectorPanel(platform, inspector, meta, width, height, frame);
+});
+
+const InspectorPane = React.memo(function InspectorPane({ controller, width, height, frame }) {
+    const inspectorMeta = useControllerSelector(controller, (state) => ({
+        inspectorTab: state.ui.inspectorTab,
+        inspectorScroll: state.ui.scroll.inspector,
+        focused: state.ui.focusRegion === "inspector",
+    }), shallowEqualObject);
     if (inspectorMeta.inspectorTab === "files") {
         return React.createElement(FilesBrowser, {
             controller,
@@ -375,40 +560,39 @@ const InspectorPane = React.memo(function InspectorPane({ controller, width, hei
             frame,
         });
     }
-    const tabLine = inspector.tabs.map((tab) => ({
-        text: tab === inspector.activeTab ? `[${tab}] ` : `${tab} `,
-        color: tab === inspector.activeTab ? "magenta" : "gray",
-        bold: tab === inspector.activeTab,
-    }));
-    const normalizedLines = inspector.lines.map((line) => (typeof line === "string"
-        ? { text: line, color: "white" }
-        : line));
-    const stickyLines = inspector.activeTab === "sequence"
-        ? [
-            tabLine,
-            ...((inspector.stickyLines || []).map((line) => (typeof line === "string"
-                ? { text: line, color: "white" }
-                : line))),
-        ]
-        : [];
-    const lines = inspector.activeTab === "sequence"
-        ? normalizedLines
-        : [tabLine, ...normalizedLines];
-
-    return React.createElement(platform.Panel, {
-        title: inspector.title,
-        color: "magenta",
-        focused: inspectorMeta.focused,
+    if (inspectorMeta.inspectorTab === "sequence") {
+        return React.createElement(InspectorSequencePane, {
+            controller,
+            width,
+            height,
+            frame,
+            meta: inspectorMeta,
+        });
+    }
+    if (inspectorMeta.inspectorTab === "logs") {
+        return React.createElement(InspectorLogsPane, {
+            controller,
+            width,
+            height,
+            frame,
+            meta: inspectorMeta,
+        });
+    }
+    if (inspectorMeta.inspectorTab === "history") {
+        return React.createElement(InspectorHistoryPane, {
+            controller,
+            width,
+            height,
+            frame,
+            meta: inspectorMeta,
+        });
+    }
+    return React.createElement(InspectorNodesPane, {
+        controller,
         width,
         height,
-        stickyLines,
-        marginBottom: PANE_GAP_Y,
-        lines,
-        scrollOffset: inspectorMeta.inspectorScroll,
-        scrollMode: inspector.activeTab === "logs" || inspector.activeTab === "sequence" ? "bottom" : "top",
-        paneId: "inspector",
-        paneLabel: inspector.activeTab === "sequence" ? "Sequence" : "Inspector",
         frame,
+        meta: inspectorMeta,
     });
 });
 

--- a/run.sh
+++ b/run.sh
@@ -68,20 +68,21 @@ export SESSION_STATE_DIR="${LOCAL_TMP}/session-state"
 export SESSION_STORE_DIR="${LOCAL_TMP}/session-store"
 export ARTIFACT_DIR="${LOCAL_TMP}/artifacts"
 export PILOTSWARM_WORKER_SHUTDOWN_TIMEOUT_MS="${PILOTSWARM_WORKER_SHUTDOWN_TIMEOUT_MS:-1000}"
+export NODE_ENV="${NODE_ENV:-production}"
 
 case "$MODE" in
     local)
         if [[ "${2:-}" == "--db" ]]; then
             echo "🚀 Starting TUI — 4 local workers, local PG (Ctrl+C to quit)"
-            exec node packages/cli/bin/tui.js local --env .env
+            exec node --max-old-space-size=512 packages/cli/bin/tui.js local --env .env
         else
             echo "🚀 Starting TUI — 4 local workers, remote PG (Ctrl+C to quit)"
-            exec node packages/cli/bin/tui.js local --env .env.remote
+            exec node --max-old-space-size=2048 packages/cli/bin/tui.js local --env .env.remote
         fi
         ;;
     remote|scaled)
         echo "🚀 Starting TUI — AKS workers, client-only (Ctrl+C to quit)"
-        exec node packages/cli/bin/tui.js remote --env .env.remote
+        exec node --max-old-space-size=512 packages/cli/bin/tui.js remote --env .env.remote
         ;;
     *)
         echo "Usage: $0 [local|remote] [--db]"


### PR DESCRIPTION
## What changed

This PR reduces the worst TUI memory amplifiers we found during the April 6, 2026 remote-mode OOM investigation.

It includes:
- forcing the shipped TUI onto production React/Ink
- removing no-op session churn in controller/reducer/store paths
- batching log-tail updates
- narrowing startup inspector hydration so sequence mode no longer loads history for every session up front
- reducing inactive-pane refresh costs in the shared React UI
- adding a live RSS readout to the Sessions pane header for ongoing TUI debugging
- documenting the current findings and remaining work in the investigation write-up

## Why it changed

The remote TUI was showing severe memory growth, with earlier runs climbing rapidly toward OOM. Profiling showed two different problems:
- a major dev-mode amplifier from React development builds and user-timing instrumentation
- real render/state churn from session refreshes and wide pane subscriptions

This PR addresses both classes of issues enough to move the clean startup case from immediate runaway toward a much more stable baseline.

## Impact

User-facing impact:
- remote TUI runs now default to production React
- clean chat-only runs stabilize much lower than before
- inactive inspector tabs stop paying for heavy state they are not rendering
- the Sessions pane now shows current RSS directly in the TUI header

Developer impact:
- the TUI memory investigation doc now reflects the current post-fix state
- temporary one-off heap-inspector helpers used during the debugging pass were removed from the repo

## Root cause

The main root cause was not the raw SDK layer alone. The worst growth came from the interaction between the full Ink/React tree and continuous state updates, with React development mode dramatically amplifying the cost.

## Validation

Used lightweight syntax validation on the touched runtime files:
- `node --check packages/cli/bin/tui.js`
- `node --check packages/cli/src/node-sdk-transport.js`
- `node --check packages/cli/src/platform.js`
- `node --check packages/ui-core/src/controller.js`
- `node --check packages/ui-core/src/reducer.js`
- `node --check packages/ui-core/src/selectors.js`
- `node --check packages/ui-core/src/store.js`
- `node --check packages/ui-react/src/components.js`
- `bash -n run.sh`

Manual verification during investigation:
- compared RSS trends across multiple live remote-mode runs
- confirmed clean chat-only baselines around the high-300s/low-400s MB instead of the earlier immediate runaway pattern
- confirmed that history and node-map tab switches no longer caused catastrophic jumps in clean runs
