### PR TITLE
Add eval harness package

### DIFF
--- a/packages/eval-harness/README.md
+++ b/packages/eval-harness/README.md
@@ -1,0 +1,352 @@
+# PilotSwarm Eval Harness
+
+Production-grade evaluation harness for PilotSwarm agents. Measures tool-call correctness, argument accuracy, sequencing, and session state through deterministic code graders with constraint-based matching.
+
+## Quick Start
+
+```bash
+# Run eval suite (uses FakeDriver — no LLM calls, no .env needed)
+cd packages/eval-harness
+npx vitest run
+
+# Via the repo test runner
+./scripts/run-tests.sh --suite=eval
+```
+
+## Architecture
+
+```
+                    ┌─────────────────────┐
+                    │     EvalRunner       │
+                    │  load → drive →      │
+                    │  grade → report      │
+                    └──────┬──────────────┘
+                           │
+          ┌────────────────┼────────────────┐
+          ▼                ▼                ▼
+   ┌─────────────┐  ┌───────────┐   ┌───────────┐
+   │   Driver     │  │  Graders  │   │ Reporters │
+   │             │  │           │   │           │
+   │ FakeDriver  │  │ tool-sel  │   │ Console   │
+   │ LiveDriver  │  │ match-arg │   │ JSONL     │
+   └─────────────┘  │ ordering  │   └───────────┘
+                     │ response  │
+                     │ cms-state │
+                     └───────────┘
+```
+
+**Data flow:** JSON fixture → Loader (Zod validates) → Runner → Driver (execute) → Graders (score) → Reporter (output)
+
+## Package Structure
+
+```
+packages/eval-harness/
+├── src/
+│   ├── index.ts              # Public API exports
+│   ├── types.ts              # Zod schemas + TS types
+│   ├── loader.ts             # JSON fixture loader + validation
+│   ├── runner.ts             # EvalRunner: orchestrates eval lifecycle
+│   ├── graders/
+│   │   ├── index.ts          # Composer: gradeEvalCase()
+│   │   ├── match-args.ts     # Arg matching (exact/subset/fuzzy/setEquals)
+│   │   ├── tool-selection.ts # Tool name + forbidden + call counts
+│   │   ├── ordering.ts       # Strict/unordered sequence grading
+│   │   ├── response.ts       # Word-boundary containsAny/All
+│   │   └── cms-state.ts      # CMS session state assertion
+│   ├── drivers/
+│   │   ├── types.ts          # Driver + DriverOptions interfaces
+│   │   ├── fake-driver.ts    # Scripted traces (TDD, CI, fast)
+│   │   └── live-driver.ts    # Real LLM via PilotSwarm withClient()
+│   ├── observers/
+│   │   └── tool-tracker.ts   # EvalToolTracker → ObservedToolCall[]
+│   ├── reporters/
+│   │   ├── types.ts          # Reporter interface (async-ready)
+│   │   ├── console.ts        # ✅/❌/⚠️ summary table to stdout
+│   │   └── jsonl.ts          # Incremental JSONL + failure artifacts
+│   └── fixtures/
+│       └── eval-tools.ts     # test_add, test_multiply, test_weather
+├── test/                     # 15 test files, 196 tests
+├── datasets/
+│   └── tool-call-correctness.v1.json   # Golden dataset v1 (6 cases)
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+└── README.md
+```
+
+## Core Concepts
+
+### Fixture (EvalTask)
+
+A JSON file defining a set of eval scenarios:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "tool-call-correctness",
+  "name": "Tool Call Correctness",
+  "description": "Core tool calling scenarios",
+  "version": "1.0.0",
+  "passRateFloor": 0.8,
+  "samples": [...]
+}
+```
+
+### Sample (EvalSample)
+
+A single eval scenario within a task:
+
+```json
+{
+  "id": "single.add.basic",
+  "description": "Single tool call with integer args",
+  "input": {
+    "prompt": "What is 17 plus 25? Use the test_add tool.",
+    "systemMessage": "You have tools available. Use them when asked. Be brief."
+  },
+  "expected": {
+    "toolCalls": [
+      { "name": "test_add", "args": { "a": 17, "b": 25 }, "match": "subset" }
+    ],
+    "forbiddenTools": [],
+    "response": { "containsAny": ["42"] },
+    "cms": { "stateIn": ["idle", "completed"] }
+  },
+  "tools": ["test_add"],
+  "tags": ["single-tool", "arithmetic"],
+  "timeoutMs": 120000
+}
+```
+
+### Score
+
+Every grader returns normalized scores:
+
+```typescript
+{
+  name: "tool-names",       // which grader
+  value: 1.0,               // 0..1 normalized
+  pass: true,               // binary verdict
+  reason: "all 1 expected tool(s) were called",
+  actual: ["test_add"],     // what the LLM did
+  expected: ["test_add"]    // what we expected
+}
+```
+
+A case passes only when **all** applicable scores pass.
+
+### Driver
+
+Drivers execute eval samples and return observed results:
+
+| Driver | Purpose | LLM Calls | Speed |
+|--------|---------|-----------|-------|
+| `FakeDriver` | TDD, CI, fast iteration | No | <1ms/case |
+| `LiveDriver` | Real model evaluation | Yes | 5-30s/case |
+
+### Reporter
+
+Reporters receive events as evals execute:
+
+| Reporter | Output | Use Case |
+|----------|--------|----------|
+| `ConsoleReporter` | ✅/❌/⚠️ table to stdout | Interactive use |
+| `JsonlReporter` | `.eval-results/<runId>.jsonl` + failure artifacts | CI, history |
+
+Reporter interface is async-ready (`void | Promise<void>`) for future Langfuse integration.
+
+## Grading Reference
+
+### Argument Matching Modes
+
+| Mode | Behavior | Default |
+|------|----------|---------|
+| `exact` | JSON equality after key sorting | |
+| `subset` | Every expected key must match; extra actual keys OK. Strings case-insensitive + trimmed. | ✅ |
+| `fuzzy` | Levenshtein for strings (≤20% distance), numeric tolerance (±0.01), order-insensitive arrays | |
+| `setEquals` | Same keys and values in both directions, order-insensitive | |
+
+### Tool Selection Scoring
+
+| Score | What It Checks |
+|-------|---------------|
+| `tool-names` | Were the right tools called? (multiset counting — handles duplicate calls) |
+| `forbidden-tools` | Were forbidden tools avoided? |
+| `call-count` | Were `minCalls`/`maxCalls` constraints met? |
+| `no-tool-compliance` | If `noToolCall: true`, were zero tools called? |
+| `tool-args:<name>` | Per expected tool call, did the arguments match? (uses selected match mode) |
+
+### Ordering
+
+| Mode | Behavior |
+|------|----------|
+| `strict` | Expected tools appear in order as a subsequence of observed calls |
+| `unordered` | All expected tools appear somewhere in observed (any order) |
+
+### Response Matching
+
+Uses **word-boundary matching** (regex `\b...\b`) for `containsAny`/`containsAll` — prevents false positives like `"hi"` matching `"this"`.
+
+### Schema Validation
+
+Zod validates fixtures at load time with cross-field invariants:
+- Rejects `noToolCall: true` combined with `toolCalls`
+- Rejects `minCalls > maxCalls`
+- Requires `schemaVersion: 1`
+- Requires at least one sample
+
+## Adding a New Eval Case
+
+### Step 1: Add to the dataset
+
+Edit `datasets/tool-call-correctness.v1.json` and add a sample:
+
+```json
+{
+  "id": "selection.divide-not-multiply",
+  "description": "Should pick divide, not multiply",
+  "input": {
+    "prompt": "What is 20 divided by 4? Use the appropriate tool.",
+    "systemMessage": "You have math tools. Use the correct one."
+  },
+  "expected": {
+    "toolCalls": [{ "name": "test_divide", "args": { "a": 20, "b": 4 }, "match": "subset" }],
+    "forbiddenTools": ["test_multiply"]
+  },
+  "tools": ["test_multiply", "test_divide"],
+  "tags": ["selection"]
+}
+```
+
+### Step 2: Add a fake scenario for CI
+
+In `test/eval-core.test.ts`, add a matching fake response:
+
+```typescript
+"selection.divide-not-multiply": {
+  toolCalls: [{ name: "test_divide", args: { a: 20, b: 4 }, result: { result: 5 }, order: 0 }],
+  finalResponse: "20 ÷ 4 = 5.",
+  sessionId: "fake-session-new",
+  latencyMs: 100,
+  cmsState: "idle",
+},
+```
+
+### Step 3: Run
+
+```bash
+cd packages/eval-harness && npx vitest run
+```
+
+### Step 4 (optional): Add new eval tools
+
+If your scenario needs a new tool, add it to `src/fixtures/eval-tools.ts` and register in `createEvalToolTracker()`.
+
+## Running Against a Real Model
+
+The `LiveDriver` executes samples against a real LLM via PilotSwarm's `withClient()` pattern.
+
+**Prerequisites:**
+- PostgreSQL running (`DATABASE_URL` in `.env`)
+- `GITHUB_TOKEN` in `.env` (or model provider keys in `.model_providers.json`)
+
+**Example usage in a test:**
+
+```typescript
+import { LiveDriver } from "../src/drivers/live-driver.js";
+import { EvalRunner } from "../src/runner.js";
+import { loadEvalTask } from "../src/loader.js";
+import { ConsoleReporter } from "../src/reporters/console.js";
+import { JsonlReporter } from "../src/reporters/jsonl.js";
+
+const task = loadEvalTask("datasets/tool-call-correctness.v1.json");
+const runner = new EvalRunner({
+  driver: new LiveDriver({ model: "gpt-4o" }),
+  reporters: [new ConsoleReporter(), new JsonlReporter(".eval-results")],
+});
+
+const result = await runner.runTask(task);
+console.log(`Pass rate: ${(result.summary.passRate * 100).toFixed(1)}%`);
+```
+
+**Current LiveDriver limitations:**
+- Does not support `input.context` (multi-turn priors) — will throw
+- Each sample creates an isolated test environment (fresh DB schemas)
+- `workerNodeId` is unique per run to avoid collisions
+
+## JSONL Output Format
+
+Each run produces `.eval-results/<runId>.jsonl`:
+
+```jsonl
+{"type":"run","runId":"abc-123","task":"tool-call-correctness","version":"1.0.0","startedAt":"..."}
+{"type":"sample","runId":"abc-123","caseId":"single.add.basic","pass":true,"scores":[...],"observed":{...},"durationMs":102}
+{"type":"sample","runId":"abc-123","caseId":"selection.multiply-not-add","pass":false,"scores":[...],"observed":{...},"durationMs":8421}
+{"type":"summary","runId":"abc-123","total":6,"passed":5,"failed":1,"errored":0,"passRate":0.833}
+```
+
+Failed cases also get a detailed artifact: `.eval-results/<runId>/<caseId>.json`
+
+File paths are sanitized — `runId` and `caseId` are stripped of path separators.
+
+## Extension Points (Phase 2+)
+
+The harness is designed for incremental extension:
+
+| Interface | V1 Implementation | Future |
+|-----------|-------------------|--------|
+| `Driver` | FakeDriver, LiveDriver | MCP driver, remote AKS driver |
+| `Reporter` | Console, JSONL | Langfuse reporter, OTel exporter |
+| Graders | Code-only (deterministic) | LLM-as-judge, trajectory scoring |
+| Datasets | Static JSON | Synthetic generation, trace-to-dataset |
+| Matrix | Single model | Model × context × compaction × reasoning |
+
+### Writing a Custom Reporter
+
+```typescript
+import type { Reporter } from "pilotswarm-eval-harness";
+
+class LangfuseReporter implements Reporter {
+  async onRunStart(task, runId) { /* create Langfuse trace */ }
+  async onCaseResult(result) { /* log span + scores */ }
+  async onRunComplete(result) { /* finalize trace */ }
+}
+```
+
+### Writing a Custom Driver
+
+```typescript
+import type { Driver, DriverOptions } from "pilotswarm-eval-harness";
+
+class RemoteDriver implements Driver {
+  async run(sample, options) {
+    // Call remote PilotSwarm cluster
+    // options.signal for cancellation
+    return { toolCalls: [...], finalResponse: "...", sessionId: "...", latencyMs: 0 };
+  }
+}
+```
+
+## Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Constraint-based matching (not exact) | LLMs add harmless extra args; exact match → false failures |
+| `subset` as default match mode | Most lenient useful mode; tighten per-case with `exact`/`setEquals` |
+| Word-boundary response matching | Prevents `"hi"` matching `"this"` — substring matching is a footgun |
+| Eval-owned system prompts | Each fixture controls its own prompt; not "compensating for product behavior" |
+| FakeDriver for CI | Fast (< 1s total), free, deterministic — tests the harness, not the model |
+| AbortSignal on Driver | Timeouts actually cancel work — no leaked LLM calls or orphaned resources |
+| Async-ready Reporter | `void | Promise<void>` — Langfuse/OTel plug in without interface changes |
+| Incremental JSONL writes | Crash mid-run → partial results preserved (not buffered-then-lost) |
+| Specificity-ordered arg matching | Most-constrained expectations matched first → avoids greedy mis-pairing |
+| Path-sanitized artifacts | `runId`/`caseId` stripped of separators → no path traversal |
+
+## Relationship to Existing Tests
+
+| Existing Tests (`packages/sdk/test/local/`) | Eval Harness (`packages/eval-harness/`) |
+|---------------------------------------------|----------------------------------------|
+| Assert **system** behavior (events fire, CMS persists, orchestration replays) | Measure **LLM** behavior (tool selection, arg accuracy, sequencing) |
+| One run, hard fail | passRateFloor, statistical signal (multi-trial in V2) |
+| vitest `describe`/`it` | Same runner, different semantics |
+| Share: `withClient()`, PilotSwarm SDK, CMS helpers | Share: tool definitions pattern, test env isolation |

--- a/packages/eval-harness/datasets/tool-call-correctness.v1.json
+++ b/packages/eval-harness/datasets/tool-call-correctness.v1.json
@@ -1,0 +1,108 @@
+{
+  "schemaVersion": 1,
+  "id": "tool-call-correctness",
+  "name": "Tool Call Correctness",
+  "description": "Core tool calling scenarios — single tool, multi-param, selection, no-tool, sequencing, unordered",
+  "version": "1.0.0",
+  "passRateFloor": 0.8,
+  "samples": [
+    {
+      "id": "single.add.basic",
+      "description": "Single tool call with integer args",
+      "input": {
+        "prompt": "What is 17 plus 25? Use the test_add tool.",
+        "systemMessage": "You have tools available. When asked to perform calculations, use the appropriate tool. Be brief and answer with just the result."
+      },
+      "expected": {
+        "toolCalls": [{ "name": "test_add", "args": { "a": 17, "b": 25 }, "match": "subset" }],
+        "response": { "containsAny": ["42"] },
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_add"],
+      "tags": ["single-tool", "arithmetic"]
+    },
+    {
+      "id": "single.weather.multi-param",
+      "description": "Multi-parameter tool call with string and optional args",
+      "input": {
+        "prompt": "What's the weather in Tokyo? Use the test_weather tool.",
+        "systemMessage": "You have tools available. When asked about weather, use the test_weather tool. Be brief."
+      },
+      "expected": {
+        "toolCalls": [{ "name": "test_weather", "args": { "city": "Tokyo" }, "match": "subset" }],
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_weather"],
+      "tags": ["single-tool", "multi-param"]
+    },
+    {
+      "id": "selection.multiply-not-add",
+      "description": "Tool selection — should pick multiply, not add",
+      "input": {
+        "prompt": "What is 4 times 5? Use the appropriate tool.",
+        "systemMessage": "You have math tools available: test_add for addition, test_multiply for multiplication. Use the correct one. Be brief."
+      },
+      "expected": {
+        "toolCalls": [{ "name": "test_multiply", "args": { "a": 4, "b": 5 }, "match": "subset" }],
+        "forbiddenTools": ["test_add"],
+        "response": { "containsAny": ["20"] },
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_add", "test_multiply"],
+      "tags": ["selection", "arithmetic"]
+    },
+    {
+      "id": "selection.no-tool-with-tools",
+      "description": "Should NOT use any tool — just respond directly",
+      "input": {
+        "prompt": "Say hello to the user. Do not use any tools.",
+        "systemMessage": "You have tools available but should only use them when specifically asked to perform calculations or check weather. If the user just wants a greeting, respond directly without tools. Be brief."
+      },
+      "expected": {
+        "noToolCall": true,
+        "response": { "containsAny": ["hello", "greetings"] },
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_add", "test_weather"],
+      "tags": ["no-tool", "negative"]
+    },
+    {
+      "id": "sequence.add-then-multiply",
+      "description": "Sequential tool calls — add first, then multiply",
+      "input": {
+        "prompt": "First add 2 and 3 using test_add, then multiply 4 and 5 using test_multiply. Do them in that exact order.",
+        "systemMessage": "You have math tools. When asked to perform multiple operations, do them in the order specified. Use test_add for addition and test_multiply for multiplication. Be brief."
+      },
+      "expected": {
+        "toolCalls": [
+          { "name": "test_add", "args": { "a": 2, "b": 3 }, "match": "subset", "order": 0 },
+          { "name": "test_multiply", "args": { "a": 4, "b": 5 }, "match": "subset", "order": 1 }
+        ],
+        "toolSequence": "strict",
+        "minCalls": 2,
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_add", "test_multiply"],
+      "tags": ["sequencing", "multi-tool"]
+    },
+    {
+      "id": "multi.unordered-weather",
+      "description": "Multiple calls to same tool — order doesn't matter",
+      "input": {
+        "prompt": "Check the weather in both Tokyo and London using the test_weather tool for each city.",
+        "systemMessage": "You have a weather tool. When asked about multiple cities, call test_weather once for each city. Be brief."
+      },
+      "expected": {
+        "toolCalls": [
+          { "name": "test_weather", "args": { "city": "Tokyo" }, "match": "subset" },
+          { "name": "test_weather", "args": { "city": "London" }, "match": "subset" }
+        ],
+        "toolSequence": "unordered",
+        "minCalls": 2,
+        "cms": { "stateIn": ["idle", "completed"] }
+      },
+      "tools": ["test_weather"],
+      "tags": ["multi-tool", "unordered"]
+    }
+  ]
+}

--- a/packages/eval-harness/package.json
+++ b/packages/eval-harness/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "pilotswarm-eval-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "zod": "^3.23.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.0",
+    "vitest": "^4.1.0"
+  },
+  "peerDependencies": {
+    "pilotswarm-sdk": "^0.1.18"
+  }
+}

--- a/packages/eval-harness/src/drivers/fake-driver.ts
+++ b/packages/eval-harness/src/drivers/fake-driver.ts
@@ -1,0 +1,35 @@
+import type { Driver, DriverOptions } from "./types.js";
+import type { EvalSample, ObservedResult } from "../types.js";
+
+export interface FakeScenario {
+  sampleId: string;
+  response: ObservedResult;
+}
+
+export class FakeDriver implements Driver {
+  private scenarios: Map<string, ObservedResult>;
+
+  constructor(scenarios: FakeScenario[]) {
+    this.scenarios = new Map(scenarios.map((s) => [s.sampleId, s.response]));
+  }
+
+  async run(sample: EvalSample, options?: DriverOptions): Promise<ObservedResult> {
+    const response = this.scenarios.get(sample.id);
+    if (!response) {
+      throw new Error(`FakeDriver: unknown sampleId "${sample.id}"`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1));
+    if (options?.signal?.aborted) {
+      throw new Error(`FakeDriver: aborted while serving sample "${sample.id}"`);
+    }
+    return structuredClone(response);
+  }
+
+  static fromMap(map: Record<string, ObservedResult>): FakeDriver {
+    const scenarios: FakeScenario[] = Object.entries(map).map(([sampleId, response]) => ({
+      sampleId,
+      response,
+    }));
+    return new FakeDriver(scenarios);
+  }
+}

--- a/packages/eval-harness/src/drivers/live-driver.ts
+++ b/packages/eval-harness/src/drivers/live-driver.ts
@@ -1,0 +1,188 @@
+import { randomBytes } from "node:crypto";
+import type { Driver, DriverOptions } from "./types.js";
+import type { EvalSample, ObservedResult, ObservedToolCall } from "../types.js";
+import { createEvalToolTracker } from "../fixtures/eval-tools.js";
+import { extractObservedCalls } from "../observers/tool-tracker.js";
+import { PilotSwarmClient, PilotSwarmWorker } from "pilotswarm-sdk";
+// createTestEnv is a test helper from the sdk package that is not part of the
+// public API; import it by relative path from the sdk's test helpers. The sdk
+// helpers are plain .js with no types, so suppress the declaration lookup.
+// @ts-expect-error - no types for sdk test helper
+import { createTestEnv } from "../../../sdk/test/helpers/local-env.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyCtor = new (...args: any[]) => any;
+
+export interface LiveDriverDeps {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  createEnv?: (suite: string) => any;
+  WorkerCtor?: AnyCtor;
+  ClientCtor?: AnyCtor;
+}
+
+export class LiveDriver implements Driver {
+  private defaultOptions: DriverOptions;
+  private deps: LiveDriverDeps;
+
+  constructor(options?: DriverOptions, deps?: LiveDriverDeps) {
+    this.defaultOptions = options ?? {};
+    this.deps = deps ?? {};
+  }
+
+  async run(sample: EvalSample, options?: DriverOptions): Promise<ObservedResult> {
+    const opts: DriverOptions = { ...this.defaultOptions, ...(options ?? {}) };
+
+    if (sample.input.context && sample.input.context.length > 0) {
+      throw new Error(
+        "LiveDriver does not yet support conversation context. Remove context from sample or use FakeDriver.",
+      );
+    }
+
+    const { tracker, tools } = createEvalToolTracker();
+    const toolByName: Record<string, (typeof tools)[keyof typeof tools]> = {
+      test_add: tools.add,
+      test_multiply: tools.multiply,
+      test_weather: tools.weather,
+    };
+
+    const requested = sample.tools ?? ["test_add", "test_multiply", "test_weather"];
+    const missing = requested.filter((name) => !toolByName[name]);
+    if (missing.length > 0) {
+      throw new Error(
+        `Unknown eval tool(s): ${missing.join(", ")}. Available: ${Object.keys(toolByName).join(", ")}`,
+      );
+    }
+    const selectedTools = requested.map((name) => toolByName[name]);
+    const selectedToolNames = requested;
+
+    // Track lifecycle ownership flags so cleanup runs in reverse order regardless of failure point.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let env: any | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let worker: any | undefined;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let client: any | undefined;
+    let workerStarted = false;
+    let clientStarted = false;
+    let abortHandler: (() => void) | undefined;
+
+    const startedAt = Date.now();
+    let sessionId = "";
+    let finalResponse = "";
+    let cmsState: string | undefined;
+
+    try {
+      const envFactory = this.deps.createEnv ?? createTestEnv;
+      env = envFactory(`eval_${sample.id}`);
+
+      const WorkerCtor = (this.deps.WorkerCtor ?? PilotSwarmWorker) as AnyCtor;
+      const ClientCtor = (this.deps.ClientCtor ?? PilotSwarmClient) as AnyCtor;
+
+      const workerNodeId = `eval-${randomBytes(4).toString("hex")}`;
+
+      worker = new WorkerCtor({
+        store: opts.store ?? env.store,
+        githubToken: process.env.GITHUB_TOKEN,
+        duroxideSchema: env.duroxideSchema,
+        cmsSchema: env.cmsSchema,
+        factsSchema: env.factsSchema,
+        sessionStateDir: env.sessionStateDir,
+        workerNodeId,
+        disableManagementAgents: true,
+        logLevel: process.env.DUROXIDE_LOG_LEVEL || "error",
+      });
+      if (selectedTools.length > 0) worker.registerTools(selectedTools);
+      await worker.start();
+      workerStarted = true;
+
+      client = new ClientCtor({
+        store: opts.store ?? env.store,
+        duroxideSchema: env.duroxideSchema,
+        cmsSchema: env.cmsSchema,
+        factsSchema: env.factsSchema,
+      });
+      await client.start();
+      clientStarted = true;
+
+      const sessionConfig: {
+        systemMessage?: string;
+        model?: string;
+        toolNames?: string[];
+      } = {};
+      if (sample.input.systemMessage) sessionConfig.systemMessage = sample.input.systemMessage;
+      if (opts.model) sessionConfig.model = opts.model;
+      if (selectedToolNames.length > 0) sessionConfig.toolNames = selectedToolNames;
+
+      const session = await client.createSession(sessionConfig);
+      sessionId = session.sessionId;
+      worker.setSessionConfig(sessionId, { ...sessionConfig, tools: selectedTools });
+
+      // Race the prompt against the AbortSignal so an external abort (e.g. Runner timeout)
+      // unblocks us promptly and lets the finally block tear everything down.
+      const sendPromise = session.sendAndWait(sample.input.prompt, opts.timeout);
+      let abortPromise: Promise<never> | undefined;
+      if (opts.signal) {
+        if (opts.signal.aborted) {
+          throw new Error(`LiveDriver: aborted before send for sample "${sample.id}"`);
+        }
+        abortPromise = new Promise<never>((_, reject) => {
+          abortHandler = () => reject(new Error(`LiveDriver: aborted via signal for sample "${sample.id}"`));
+          opts.signal!.addEventListener("abort", abortHandler, { once: true });
+        });
+      }
+      const response = abortPromise
+        ? await Promise.race([sendPromise, abortPromise])
+        : await sendPromise;
+      finalResponse = (response as string | undefined) ?? "";
+
+      const info = await session.getInfo().catch(() => null);
+      cmsState = info?.state ?? undefined;
+    } finally {
+      if (abortHandler && opts.signal) {
+        try {
+          opts.signal.removeEventListener("abort", abortHandler);
+        } catch {
+          /* ignore */
+        }
+      }
+      if (clientStarted && client) {
+        try {
+          await client.stop();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (workerStarted && worker) {
+        try {
+          await worker.stop();
+        } catch {
+          /* ignore */
+        }
+      }
+      if (env) {
+        try {
+          await env.cleanup();
+        } catch {
+          /* ignore */
+        }
+      }
+    }
+
+    const latencyMs = Date.now() - startedAt;
+    const toolCalls: ObservedToolCall[] = extractObservedCalls(tracker);
+
+    const result: ObservedResult = {
+      toolCalls,
+      finalResponse,
+      sessionId,
+      latencyMs,
+    };
+    if (opts.model) result.model = opts.model;
+    if (cmsState) result.cmsState = cmsState;
+    return result;
+  }
+
+  async dispose(): Promise<void> {
+    // No persistent state to clean up — each run() creates its own env.
+  }
+}

--- a/packages/eval-harness/src/drivers/types.ts
+++ b/packages/eval-harness/src/drivers/types.ts
@@ -1,0 +1,13 @@
+import type { EvalSample, ObservedResult } from "../types.js";
+
+export interface DriverOptions {
+  store?: string;
+  model?: string;
+  timeout?: number;
+  signal?: AbortSignal;
+}
+
+export interface Driver {
+  run(sample: EvalSample, options?: DriverOptions): Promise<ObservedResult>;
+  dispose?(): Promise<void>;
+}

--- a/packages/eval-harness/src/fixtures/eval-tools.ts
+++ b/packages/eval-harness/src/fixtures/eval-tools.ts
@@ -1,0 +1,120 @@
+import { defineTool } from "pilotswarm-sdk";
+
+export interface ToolInvocation {
+  name: string;
+  args: Record<string, unknown>;
+  result: unknown;
+  timestamp: number;
+  order: number;
+}
+
+export interface EvalToolTracker {
+  invocations: ToolInvocation[];
+  reset(): void;
+}
+
+export function createEvalToolTracker(): {
+  tracker: EvalToolTracker;
+  tools: {
+    add: ReturnType<typeof createEvalAddTool>;
+    multiply: ReturnType<typeof createEvalMultiplyTool>;
+    weather: ReturnType<typeof createEvalWeatherTool>;
+  };
+} {
+  const tracker: EvalToolTracker = {
+    invocations: [],
+    reset() {
+      this.invocations = [];
+    },
+  };
+  return {
+    tracker,
+    tools: {
+      add: createEvalAddTool(tracker),
+      multiply: createEvalMultiplyTool(tracker),
+      weather: createEvalWeatherTool(tracker),
+    },
+  };
+}
+
+function record(
+  tracker: EvalToolTracker,
+  name: string,
+  args: Record<string, unknown>,
+  result: unknown,
+): void {
+  tracker.invocations.push({
+    name,
+    args,
+    result,
+    timestamp: Date.now(),
+    order: tracker.invocations.length,
+  });
+}
+
+export function createEvalAddTool(tracker: EvalToolTracker) {
+  return defineTool("test_add", {
+    description: "Add two numbers together. ALWAYS use this when asked to add numbers.",
+    parameters: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First number" },
+        b: { type: "number", description: "Second number" },
+      },
+      required: ["a", "b"],
+    },
+    handler: async (args: { a: number; b: number }) => {
+      const result = { result: args.a + args.b };
+      record(tracker, "test_add", args as unknown as Record<string, unknown>, result);
+      return result;
+    },
+  });
+}
+
+export function createEvalMultiplyTool(tracker: EvalToolTracker) {
+  return defineTool("test_multiply", {
+    description: "Multiply two numbers. ALWAYS use this when asked to multiply.",
+    parameters: {
+      type: "object",
+      properties: {
+        a: { type: "number", description: "First number" },
+        b: { type: "number", description: "Second number" },
+      },
+      required: ["a", "b"],
+    },
+    handler: async (args: { a: number; b: number }) => {
+      const result = { result: args.a * args.b };
+      record(tracker, "test_multiply", args as unknown as Record<string, unknown>, result);
+      return result;
+    },
+  });
+}
+
+export function createEvalWeatherTool(tracker: EvalToolTracker) {
+  return defineTool("test_weather", {
+    description: "Get the current weather for a city",
+    parameters: {
+      type: "object",
+      properties: {
+        city: { type: "string", description: "City name" },
+        unit: {
+          type: "string",
+          enum: ["celsius", "fahrenheit"],
+          description: "Temperature unit (default fahrenheit)",
+        },
+      },
+      required: ["city"],
+    },
+    handler: async (args: { city: string; unit?: "celsius" | "fahrenheit" }) => {
+      const unit = args.unit ?? "fahrenheit";
+      const result = {
+        temperature: unit === "celsius" ? 22 : 72,
+        condition: "sunny",
+        city: args.city,
+        unit,
+      };
+      record(tracker, "test_weather", args as unknown as Record<string, unknown>, result);
+      return result;
+    },
+  });
+}

--- a/packages/eval-harness/src/graders/cms-state.ts
+++ b/packages/eval-harness/src/graders/cms-state.ts
@@ -1,0 +1,22 @@
+import type { EvalExpected, Score } from "../types.js";
+
+export function gradeCmsState(
+  actualState: string | undefined,
+  expected: EvalExpected["cms"],
+): Score | undefined {
+  if (!expected || !expected.stateIn || expected.stateIn.length === 0) return undefined;
+
+  const pass = actualState !== undefined && expected.stateIn.includes(actualState);
+  return {
+    name: "cms-state",
+    value: pass ? 1 : 0,
+    pass,
+    reason: pass
+      ? `CMS state "${actualState}" is in allowed set`
+      : actualState === undefined
+        ? "CMS state is undefined but was expected"
+        : `CMS state "${actualState}" not in allowed set [${expected.stateIn.join(", ")}]`,
+    actual: actualState,
+    expected: expected.stateIn,
+  };
+}

--- a/packages/eval-harness/src/graders/index.ts
+++ b/packages/eval-harness/src/graders/index.ts
@@ -1,0 +1,83 @@
+import type { EvalExpected, ObservedResult, Score } from "../types.js";
+import { matchArgs } from "./match-args.js";
+import { gradeToolSelection } from "./tool-selection.js";
+import { gradeOrdering } from "./ordering.js";
+import { gradeResponse } from "./response.js";
+import { gradeCmsState } from "./cms-state.js";
+
+export { matchArgs, sortKeys } from "./match-args.js";
+export { gradeToolSelection } from "./tool-selection.js";
+export { gradeOrdering } from "./ordering.js";
+export { gradeResponse } from "./response.js";
+export { gradeCmsState } from "./cms-state.js";
+
+export function gradeEvalCase(observed: ObservedResult, expected: EvalExpected): Score[] {
+  const scores: Score[] = [];
+
+  scores.push(...gradeToolSelection(observed.toolCalls, expected));
+
+  if (expected.toolCalls && expected.toolCalls.length > 0) {
+    scores.push(gradeOrdering(observed.toolCalls, expected.toolCalls, expected.toolSequence ?? "unordered"));
+
+    const argScores: Score[] = [];
+    const consumed = new Set<number>();
+    // Match the most-constrained expectations first so duplicates of the same
+    // tool name don't get mis-paired by greedy declaration-order matching.
+    // Stable sort: more specified args = matched earlier.
+    const orderedExpected = expected.toolCalls
+      .map((exp, declarationOrder) => ({ exp, declarationOrder }))
+      .sort((a, b) => {
+        const aKeys = a.exp.args ? Object.keys(a.exp.args).length : 0;
+        const bKeys = b.exp.args ? Object.keys(b.exp.args).length : 0;
+        if (aKeys !== bKeys) return bKeys - aKeys;
+        return a.declarationOrder - b.declarationOrder;
+      })
+      .map(({ exp }) => exp);
+    for (const exp of orderedExpected) {
+      const candidates = observed.toolCalls
+        .map((o, idx) => ({ o, idx }))
+        .filter(({ o, idx }) => o.name === exp.name && !consumed.has(idx));
+      if (candidates.length === 0) {
+        argScores.push({
+          name: `tool-args:${exp.name}`,
+          value: 0,
+          pass: false,
+          reason: `no observed call to "${exp.name}" to match args against`,
+          expected: exp.args,
+        });
+        continue;
+      }
+      let best = { pass: false, score: 0, diff: [] as string[] };
+      let bestCall = candidates[0].o;
+      let bestIdx = candidates[0].idx;
+      for (const { o, idx } of candidates) {
+        const r = matchArgs(o.args, exp.args, exp.match ?? "subset");
+        if (r.score > best.score || (r.pass && !best.pass)) {
+          best = r;
+          bestCall = o;
+          bestIdx = idx;
+        }
+      }
+      consumed.add(bestIdx);
+      argScores.push({
+        name: `tool-args:${exp.name}`,
+        value: best.score,
+        pass: best.pass,
+        reason: best.pass
+          ? `args matched (mode=${exp.match ?? "subset"})`
+          : `args mismatch (mode=${exp.match ?? "subset"}): ${best.diff.join("; ")}`,
+        actual: bestCall.args,
+        expected: exp.args,
+      });
+    }
+    scores.push(...argScores);
+  }
+
+  const responseScore = gradeResponse(observed.finalResponse, expected.response);
+  if (responseScore) scores.push(responseScore);
+
+  const cmsScore = gradeCmsState(observed.cmsState, expected.cms);
+  if (cmsScore) scores.push(cmsScore);
+
+  return scores;
+}

--- a/packages/eval-harness/src/graders/match-args.ts
+++ b/packages/eval-harness/src/graders/match-args.ts
@@ -1,0 +1,194 @@
+export type MatchMode = "exact" | "subset" | "fuzzy" | "setEquals";
+
+export interface MatchResult {
+  pass: boolean;
+  score: number;
+  diff: string[];
+}
+
+export function sortKeys(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(sortKeys);
+  }
+  if (value !== null && typeof value === "object") {
+    const src = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(src).sort()) {
+      out[k] = sortKeys(src[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function normalizeString(s: string): string {
+  return s.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function levenshtein(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const m = a.length;
+  const n = b.length;
+  const prev = new Array<number>(n + 1);
+  const cur = new Array<number>(n + 1);
+  for (let j = 0; j <= n; j++) prev[j] = j;
+  for (let i = 1; i <= m; i++) {
+    cur[0] = i;
+    for (let j = 1; j <= n; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      cur[j] = Math.min(cur[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+    }
+    for (let j = 0; j <= n; j++) prev[j] = cur[j];
+  }
+  return prev[n];
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== typeof b) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (typeof a === "object" && typeof b === "object") {
+    const ao = a as Record<string, unknown>;
+    const bo = b as Record<string, unknown>;
+    const ak = Object.keys(ao);
+    const bk = Object.keys(bo);
+    if (ak.length !== bk.length) return false;
+    for (const k of ak) {
+      if (!(k in bo)) return false;
+      if (!deepEqual(ao[k], bo[k])) return false;
+    }
+    return true;
+  }
+  return false;
+}
+
+function subsetValueMatch(actual: unknown, expected: unknown): boolean {
+  if (typeof expected === "string" && typeof actual === "string") {
+    return actual.trim().toLowerCase() === expected.trim().toLowerCase();
+  }
+  if (expected !== null && typeof expected === "object" && !Array.isArray(expected)) {
+    if (actual === null || typeof actual !== "object" || Array.isArray(actual)) return false;
+    const exp = expected as Record<string, unknown>;
+    const act = actual as Record<string, unknown>;
+    for (const k of Object.keys(exp)) {
+      if (!(k in act)) return false;
+      if (!subsetValueMatch(act[k], exp[k])) return false;
+    }
+    return true;
+  }
+  return deepEqual(actual, expected);
+}
+
+function fuzzyValueMatch(actual: unknown, expected: unknown): boolean {
+  if (typeof expected === "string") {
+    const a = typeof actual === "string" ? actual : typeof actual === "number" ? String(actual) : null;
+    if (a === null) return false;
+    const na = normalizeString(a);
+    const ne = normalizeString(expected);
+    if (na === ne) return true;
+    const dist = levenshtein(na, ne);
+    const tolerance = Math.max(1, Math.ceil(ne.length * 0.2));
+    return dist <= tolerance;
+  }
+  if (typeof expected === "number") {
+    const a =
+      typeof actual === "number"
+        ? actual
+        : typeof actual === "string" && actual.trim() !== "" && !Number.isNaN(Number(actual))
+          ? Number(actual)
+          : null;
+    if (a === null) return false;
+    return Math.abs(a - expected) <= 0.01;
+  }
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual)) return false;
+    if (expected.length !== actual.length) return false;
+    const used = new Set<number>();
+    for (const ev of expected) {
+      let found = -1;
+      for (let i = 0; i < actual.length; i++) {
+        if (used.has(i)) continue;
+        if (fuzzyValueMatch(actual[i], ev)) {
+          found = i;
+          break;
+        }
+      }
+      if (found === -1) return false;
+      used.add(found);
+    }
+    return true;
+  }
+  if (expected !== null && typeof expected === "object") {
+    if (actual === null || typeof actual !== "object" || Array.isArray(actual)) return false;
+    const exp = expected as Record<string, unknown>;
+    const act = actual as Record<string, unknown>;
+    for (const k of Object.keys(exp)) {
+      if (!(k in act)) return false;
+      if (!fuzzyValueMatch(act[k], exp[k])) return false;
+    }
+    return true;
+  }
+  return deepEqual(actual, expected);
+}
+
+export function matchArgs(
+  actual: Record<string, unknown> | undefined,
+  expected: Record<string, unknown> | undefined,
+  mode: MatchMode = "subset",
+): MatchResult {
+  const a = actual ?? {};
+  const e = expected ?? {};
+  const diff: string[] = [];
+
+  if (mode === "exact") {
+    const ok = JSON.stringify(sortKeys(a)) === JSON.stringify(sortKeys(e));
+    if (!ok) diff.push(`exact mismatch: expected=${JSON.stringify(sortKeys(e))} actual=${JSON.stringify(sortKeys(a))}`);
+    return { pass: ok, score: ok ? 1 : 0, diff };
+  }
+
+  if (mode === "setEquals") {
+    const aKeys = Object.keys(a).sort();
+    const eKeys = Object.keys(e).sort();
+    if (aKeys.length !== eKeys.length || aKeys.some((k, i) => k !== eKeys[i])) {
+      diff.push(`key sets differ: expected=[${eKeys.join(",")}] actual=[${aKeys.join(",")}]`);
+      return { pass: false, score: 0, diff };
+    }
+    for (const k of eKeys) {
+      if (!deepEqual(a[k], e[k])) {
+        diff.push(`value mismatch for "${k}": expected=${JSON.stringify(e[k])} actual=${JSON.stringify(a[k])}`);
+      }
+    }
+    const pass = diff.length === 0;
+    return { pass, score: pass ? 1 : 0, diff };
+  }
+
+  const keys = Object.keys(e);
+  if (keys.length === 0) {
+    return { pass: true, score: 1, diff };
+  }
+
+  let matched = 0;
+  for (const k of keys) {
+    if (!(k in a)) {
+      diff.push(`missing key "${k}"`);
+      continue;
+    }
+    const ok = mode === "fuzzy" ? fuzzyValueMatch(a[k], e[k]) : subsetValueMatch(a[k], e[k]);
+    if (ok) {
+      matched++;
+    } else {
+      diff.push(`value mismatch for "${k}": expected=${JSON.stringify(e[k])} actual=${JSON.stringify(a[k])}`);
+    }
+  }
+  const score = matched / keys.length;
+  return { pass: matched === keys.length, score, diff };
+}

--- a/packages/eval-harness/src/graders/ordering.ts
+++ b/packages/eval-harness/src/graders/ordering.ts
@@ -1,0 +1,69 @@
+import type { EvalToolCall, ObservedToolCall, Score } from "../types.js";
+
+export function gradeOrdering(
+  observed: ObservedToolCall[],
+  expected: EvalToolCall[],
+  mode: "strict" | "unordered",
+): Score {
+  if (expected.length === 0) {
+    return {
+      name: "tool-ordering",
+      value: 1,
+      pass: true,
+      reason: "no expected ordering to enforce",
+    };
+  }
+
+  const expectedSorted = [...expected];
+  const allHaveOrder = expected.every((e) => typeof e.order === "number");
+  if (allHaveOrder) {
+    expectedSorted.sort((a, b) => (a.order as number) - (b.order as number));
+  }
+  const observedSorted = [...observed].sort((a, b) => a.order - b.order);
+
+  if (mode === "unordered") {
+    const remaining: string[] = observedSorted.map((o) => o.name);
+    let matched = 0;
+    for (const e of expectedSorted) {
+      const idx = remaining.indexOf(e.name);
+      if (idx !== -1) {
+        matched++;
+        remaining.splice(idx, 1);
+      }
+    }
+    const value = matched / expectedSorted.length;
+    return {
+      name: "tool-ordering",
+      value,
+      pass: matched === expectedSorted.length,
+      reason:
+        matched === expectedSorted.length
+          ? "all expected tools present (unordered)"
+          : `only ${matched}/${expectedSorted.length} expected tools present`,
+      actual: observedSorted.map((o) => o.name),
+      expected: expectedSorted.map((e) => e.name),
+    };
+  }
+
+  let i = 0;
+  let pairsMatched = 0;
+  for (const o of observedSorted) {
+    if (i >= expectedSorted.length) break;
+    if (o.name === expectedSorted[i].name) {
+      pairsMatched++;
+      i++;
+    }
+  }
+  const value = pairsMatched / expectedSorted.length;
+  const pass = pairsMatched === expectedSorted.length;
+  return {
+    name: "tool-ordering",
+    value,
+    pass,
+    reason: pass
+      ? "expected tools appeared in the correct order"
+      : `subsequence match failed: ${pairsMatched}/${expectedSorted.length} expected tools in order`,
+    actual: observedSorted.map((o) => o.name),
+    expected: expectedSorted.map((e) => e.name),
+  };
+}

--- a/packages/eval-harness/src/graders/response.ts
+++ b/packages/eval-harness/src/graders/response.ts
@@ -1,0 +1,68 @@
+import type { EvalExpected, Score } from "../types.js";
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Word-boundary aware containment check. For multi-character needles we wrap
+ * the match in `\b...\b` so that short tokens like "hi" don't silently match
+ * inside larger words like "this" or "history". For single-character needles
+ * we fall back to plain substring containment because `\b` is meaningless
+ * around non-word characters.
+ */
+function containsNeedle(haystackLower: string, needle: string): boolean {
+  if (!needle) return true;
+  const n = needle.toLowerCase();
+  if (n.length < 2) return haystackLower.includes(n);
+  // If the needle starts or ends with a non-word character, \b would not align
+  // with it — fall back to plain substring match in that case.
+  const startsWithWord = /\w/.test(n[0]);
+  const endsWithWord = /\w/.test(n[n.length - 1]);
+  if (!startsWithWord || !endsWithWord) {
+    return haystackLower.includes(n);
+  }
+  const re = new RegExp(`\\b${escapeRegExp(n)}\\b`, "i");
+  return re.test(haystackLower);
+}
+
+export function gradeResponse(
+  finalResponse: string,
+  expected: EvalExpected["response"],
+): Score | undefined {
+  if (!expected) return undefined;
+  const { containsAny, containsAll } = expected;
+  if (!containsAny && !containsAll) return undefined;
+
+  const hay = finalResponse.toLowerCase();
+  const checks: Array<{ type: string; needle: string; hit: boolean }> = [];
+
+  if (containsAll) {
+    for (const s of containsAll) {
+      checks.push({ type: "all", needle: s, hit: containsNeedle(hay, s) });
+    }
+  }
+
+  let anyHit = true;
+  if (containsAny && containsAny.length > 0) {
+    anyHit = containsAny.some((s) => containsNeedle(hay, s));
+    checks.push({ type: "any", needle: containsAny.join("|"), hit: anyHit });
+  }
+
+  const total = checks.length;
+  const hits = checks.filter((c) => c.hit).length;
+  const allCheck = containsAll ? checks.filter((c) => c.type === "all").every((c) => c.hit) : true;
+  const pass = allCheck && anyHit;
+  const value = total === 0 ? 1 : hits / total;
+
+  return {
+    name: "response-contains",
+    value,
+    pass,
+    reason: pass
+      ? "response satisfied all containment checks"
+      : `response failed ${total - hits}/${total} containment check(s)`,
+    actual: finalResponse,
+    expected,
+  };
+}

--- a/packages/eval-harness/src/graders/tool-selection.ts
+++ b/packages/eval-harness/src/graders/tool-selection.ts
@@ -1,0 +1,83 @@
+import type { EvalExpected, ObservedToolCall, Score } from "../types.js";
+
+export function gradeToolSelection(observed: ObservedToolCall[], expected: EvalExpected): Score[] {
+  const scores: Score[] = [];
+
+  if (expected.toolCalls && expected.toolCalls.length > 0) {
+    const expectedNames = expected.toolCalls.map((t) => t.name);
+    const expectedCount: Record<string, number> = {};
+    for (const n of expectedNames) expectedCount[n] = (expectedCount[n] ?? 0) + 1;
+    const observedCount: Record<string, number> = {};
+    for (const o of observed) observedCount[o.name] = (observedCount[o.name] ?? 0) + 1;
+
+    let matched = 0;
+    for (const n of expectedNames) {
+      // Each expected occurrence is satisfied iff observedCount[n] still has a remaining call.
+      if ((observedCount[n] ?? 0) > 0) {
+        matched++;
+        observedCount[n]--;
+      }
+    }
+    const value = expectedNames.length === 0 ? 1 : matched / expectedNames.length;
+    scores.push({
+      name: "tool-names",
+      value,
+      pass: matched === expectedNames.length,
+      reason:
+        matched === expectedNames.length
+          ? `all ${expectedNames.length} expected tool(s) were called`
+          : `matched ${matched}/${expectedNames.length} expected tool name(s)`,
+      actual: observed.map((o) => o.name),
+      expected: expectedNames,
+    });
+  }
+
+  if (expected.forbiddenTools && expected.forbiddenTools.length > 0) {
+    const observedNames = new Set(observed.map((o) => o.name));
+    const violated = expected.forbiddenTools.filter((n) => observedNames.has(n));
+    scores.push({
+      name: "forbidden-tools",
+      value: violated.length === 0 ? 1 : 0,
+      pass: violated.length === 0,
+      reason:
+        violated.length === 0
+          ? "no forbidden tools were called"
+          : `forbidden tool(s) called: ${violated.join(", ")}`,
+      actual: violated,
+      expected: expected.forbiddenTools,
+    });
+  }
+
+  const hasMin = typeof expected.minCalls === "number";
+  const hasMax = typeof expected.maxCalls === "number";
+  if (hasMin || hasMax) {
+    const count = observed.length;
+    const minOk = !hasMin || count >= (expected.minCalls as number);
+    const maxOk = !hasMax || count <= (expected.maxCalls as number);
+    const pass = minOk && maxOk;
+    scores.push({
+      name: "call-count",
+      value: pass ? 1 : 0,
+      pass,
+      reason: pass
+        ? `call count ${count} within bounds`
+        : `call count ${count} out of bounds (min=${expected.minCalls ?? "-"}, max=${expected.maxCalls ?? "-"})`,
+      actual: count,
+      expected: { min: expected.minCalls, max: expected.maxCalls },
+    });
+  }
+
+  if (expected.noToolCall === true) {
+    const pass = observed.length === 0;
+    scores.push({
+      name: "no-tool-compliance",
+      value: pass ? 1 : 0,
+      pass,
+      reason: pass ? "no tools called as expected" : `expected no tool calls but got ${observed.length}`,
+      actual: observed.length,
+      expected: 0,
+    });
+  }
+
+  return scores;
+}

--- a/packages/eval-harness/src/index.ts
+++ b/packages/eval-harness/src/index.ts
@@ -1,0 +1,50 @@
+// Types
+export type {
+  EvalTask,
+  EvalSample,
+  EvalExpected,
+  EvalToolCall,
+  Score,
+  ObservedToolCall,
+  ObservedResult,
+  CaseResult,
+  RunResult,
+} from "./types.js";
+export {
+  EvalTaskSchema,
+  EvalSampleSchema,
+  ScoreSchema,
+  RunResultSchema,
+} from "./types.js";
+
+// Runner
+export { EvalRunner } from "./runner.js";
+export type { RunnerOptions } from "./runner.js";
+
+// Loader
+export { loadEvalTask, loadEvalTaskFromDir } from "./loader.js";
+
+// Graders
+export { gradeEvalCase } from "./graders/index.js";
+export { matchArgs } from "./graders/match-args.js";
+
+// Drivers
+export type { Driver, DriverOptions } from "./drivers/types.js";
+export { FakeDriver } from "./drivers/fake-driver.js";
+export { LiveDriver } from "./drivers/live-driver.js";
+
+// Reporters
+export type { Reporter } from "./reporters/types.js";
+export { ConsoleReporter } from "./reporters/console.js";
+export { JsonlReporter } from "./reporters/jsonl.js";
+
+// Fixtures
+export {
+  createEvalToolTracker,
+  createEvalAddTool,
+  createEvalMultiplyTool,
+  createEvalWeatherTool,
+} from "./fixtures/eval-tools.js";
+
+// Observers
+export { extractObservedCalls } from "./observers/tool-tracker.js";

--- a/packages/eval-harness/src/loader.ts
+++ b/packages/eval-harness/src/loader.ts
@@ -1,0 +1,22 @@
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+import { EvalTaskSchema, type EvalTask } from "./types.js";
+
+export function loadEvalTask(filePath: string): EvalTask {
+  const raw = readFileSync(filePath, "utf8");
+  const parsed = JSON.parse(raw);
+  return EvalTaskSchema.parse(parsed);
+}
+
+export function loadEvalTaskFromDir(dir: string): EvalTask[] {
+  const entries = readdirSync(dir);
+  const tasks: EvalTask[] = [];
+  for (const entry of entries) {
+    if (!entry.toLowerCase().endsWith(".json")) continue;
+    const full = resolve(dir, entry);
+    const stat = statSync(full);
+    if (!stat.isFile()) continue;
+    tasks.push(loadEvalTask(full));
+  }
+  return tasks;
+}

--- a/packages/eval-harness/src/observers/tool-tracker.ts
+++ b/packages/eval-harness/src/observers/tool-tracker.ts
@@ -1,0 +1,12 @@
+import type { ObservedToolCall } from "../types.js";
+import type { EvalToolTracker } from "../fixtures/eval-tools.js";
+
+export function extractObservedCalls(tracker: EvalToolTracker): ObservedToolCall[] {
+  return tracker.invocations.map((inv) => ({
+    name: inv.name,
+    args: inv.args,
+    result: inv.result,
+    timestamp: inv.timestamp,
+    order: inv.order,
+  }));
+}

--- a/packages/eval-harness/src/reporters/console.ts
+++ b/packages/eval-harness/src/reporters/console.ts
@@ -1,0 +1,37 @@
+import type { EvalTask, CaseResult, RunResult } from "../types.js";
+import type { Reporter } from "./types.js";
+
+export class ConsoleReporter implements Reporter {
+  onRunStart(task: EvalTask, runId: string): void {
+    console.log(`━━━ Eval: ${task.name} v${task.version} ━━━`);
+    console.log(`Run ID: ${runId}`);
+  }
+
+  onCaseResult(result: CaseResult): void {
+    if (result.infraError) {
+      console.log(`  ⚠️  ${result.caseId} (${result.durationMs}ms)`);
+      console.log(`      error: ${result.infraError}`);
+      return;
+    }
+    const icon = result.pass ? "✅" : "❌";
+    console.log(`  ${icon} ${result.caseId} (${result.durationMs}ms)`);
+    if (!result.pass) {
+      for (const score of result.scores) {
+        if (!score.pass) {
+          console.log(`      - ${score.name}: ${score.reason}`);
+        }
+      }
+    }
+  }
+
+  onRunComplete(result: RunResult): void {
+    const { total, passed, passRate } = result.summary;
+    const pct = (passRate * 100).toFixed(1);
+    console.log(`━━━ Results: ${passed}/${total} passed (${pct}%) ━━━`);
+    const startMs = Date.parse(result.startedAt);
+    const endMs = Date.parse(result.finishedAt);
+    if (!Number.isNaN(startMs) && !Number.isNaN(endMs)) {
+      console.log(`Duration: ${endMs - startMs}ms`);
+    }
+  }
+}

--- a/packages/eval-harness/src/reporters/jsonl.ts
+++ b/packages/eval-harness/src/reporters/jsonl.ts
@@ -1,0 +1,81 @@
+import { writeFileSync, appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { EvalTask, CaseResult, RunResult } from "../types.js";
+import type { Reporter } from "./types.js";
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+function sanitizeFileId(id: string, fallback: string): string {
+  if (!id) return fallback;
+  if (SAFE_ID_RE.test(id)) return id;
+  const cleaned = id.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "");
+  return cleaned.length > 0 ? cleaned : fallback;
+}
+
+export class JsonlReporter implements Reporter {
+  private outputDir: string;
+  private runId = "";
+  private filePath = "";
+  private artifactDir = "";
+
+  constructor(outputDir: string) {
+    this.outputDir = outputDir;
+  }
+
+  onRunStart(task: EvalTask, runId: string): void {
+    this.runId = sanitizeFileId(runId, "run");
+    mkdirSync(this.outputDir, { recursive: true });
+    this.filePath = join(this.outputDir, `${this.runId}.jsonl`);
+    this.artifactDir = join(this.outputDir, this.runId);
+    const header =
+      JSON.stringify({
+        type: "run",
+        runId: this.runId,
+        task: task.id,
+        version: task.version,
+        startedAt: new Date().toISOString(),
+      }) + "\n";
+    writeFileSync(this.filePath, header, "utf8");
+  }
+
+  onCaseResult(result: CaseResult): void {
+    const line =
+      JSON.stringify({
+        type: "sample",
+        runId: this.runId,
+        caseId: result.caseId,
+        pass: result.pass,
+        scores: result.scores,
+        observed: result.observed,
+        infraError: result.infraError,
+        durationMs: result.durationMs,
+      }) + "\n";
+    appendFileSync(this.filePath, line, "utf8");
+
+    if (!result.pass) {
+      mkdirSync(this.artifactDir, { recursive: true });
+      const safeCaseId = sanitizeFileId(result.caseId, "case");
+      writeFileSync(
+        join(this.artifactDir, `${safeCaseId}.json`),
+        JSON.stringify(result, null, 2),
+        "utf8",
+      );
+    }
+  }
+
+  onRunComplete(result: RunResult): void {
+    const summary =
+      JSON.stringify({
+        type: "summary",
+        runId: this.runId,
+        total: result.summary.total,
+        passed: result.summary.passed,
+        failed: result.summary.failed,
+        errored: result.summary.errored,
+        passRate: result.summary.passRate,
+        startedAt: result.startedAt,
+        finishedAt: result.finishedAt,
+      }) + "\n";
+    appendFileSync(this.filePath, summary, "utf8");
+  }
+}

--- a/packages/eval-harness/src/reporters/types.ts
+++ b/packages/eval-harness/src/reporters/types.ts
@@ -1,0 +1,7 @@
+import type { EvalTask, CaseResult, RunResult } from "../types.js";
+
+export interface Reporter {
+  onRunStart(task: EvalTask, runId: string): void | Promise<void>;
+  onCaseResult(result: CaseResult): void | Promise<void>;
+  onRunComplete(result: RunResult): void | Promise<void>;
+}

--- a/packages/eval-harness/src/runner.ts
+++ b/packages/eval-harness/src/runner.ts
@@ -1,0 +1,172 @@
+import { randomUUID } from "node:crypto";
+import type { Driver } from "./drivers/types.js";
+import type { EvalTask, EvalSample, CaseResult, RunResult, Score } from "./types.js";
+import type { Reporter } from "./reporters/types.js";
+import { gradeEvalCase } from "./graders/index.js";
+
+export interface RunnerOptions {
+  driver: Driver;
+  reporters?: Reporter[];
+  runId?: string;
+  gitSha?: string;
+  model?: string;
+}
+
+const SAFE_ID_RE = /^[a-zA-Z0-9_-]+$/;
+
+function sanitizeId(id: string): string {
+  if (!id) return "run";
+  if (SAFE_ID_RE.test(id)) return id;
+  // Replace any character outside the safe set; collapse runs; trim.
+  const cleaned = id.replace(/[^a-zA-Z0-9_-]+/g, "_").replace(/^_+|_+$/g, "");
+  return cleaned.length > 0 ? cleaned : "run";
+}
+
+export class EvalRunner {
+  private driver: Driver;
+  private reporters: Reporter[];
+  private fixedRunId?: string;
+  private runId: string;
+  private gitSha?: string;
+  private model?: string;
+
+  constructor(options: RunnerOptions) {
+    this.driver = options.driver;
+    this.reporters = options.reporters ?? [];
+    this.fixedRunId = options.runId !== undefined ? sanitizeId(options.runId) : undefined;
+    this.runId = this.fixedRunId ?? sanitizeId(randomUUID());
+    this.gitSha = options.gitSha;
+    this.model = options.model;
+  }
+
+  private async safeReporter<K extends keyof Reporter>(
+    method: K,
+    ...args: Parameters<Reporter[K]>
+  ): Promise<void> {
+    for (const r of this.reporters) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const ret = (r[method] as any).apply(r, args);
+        if (ret && typeof (ret as Promise<unknown>).then === "function") {
+          await ret;
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[EvalRunner] reporter ${String(method)} threw: ${msg}`);
+      }
+    }
+  }
+
+  async runTask(task: EvalTask): Promise<RunResult> {
+    // Generate a fresh runId per runTask call when none was fixed in the constructor.
+    // This prevents successive runTask invocations from overwriting each other's JSONL
+    // output and artifact directories.
+    this.runId = this.fixedRunId ?? sanitizeId(randomUUID());
+
+    const startedAt = new Date().toISOString();
+    await this.safeReporter("onRunStart", task, this.runId);
+
+    const cases: CaseResult[] = [];
+    for (const sample of task.samples) {
+      const caseResult = await this.runCase(sample);
+      cases.push(caseResult);
+      await this.safeReporter("onCaseResult", caseResult);
+    }
+
+    const passed = cases.filter((c) => c.pass).length;
+    const errored = cases.filter((c) => !!c.infraError).length;
+    const failed = cases.filter((c) => !c.pass && !c.infraError).length;
+
+    const result: RunResult = {
+      schemaVersion: 1,
+      runId: this.runId,
+      taskId: task.id,
+      taskVersion: task.version,
+      gitSha: this.gitSha,
+      model: this.model,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      summary: {
+        total: cases.length,
+        passed,
+        failed,
+        errored,
+        passRate: cases.length > 0 ? passed / cases.length : 0,
+      },
+      cases,
+    };
+
+    await this.safeReporter("onRunComplete", result);
+    return result;
+  }
+
+  private async runCase(sample: EvalSample): Promise<CaseResult> {
+    const start = Date.now();
+    const timeoutMs = sample.timeoutMs;
+    const controller = new AbortController();
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutHandle = setTimeout(() => {
+          controller.abort();
+          reject(new Error(`Driver timeout after ${timeoutMs}ms for sample "${sample.id}"`));
+        }, timeoutMs);
+      });
+      let observed;
+      try {
+        observed = await Promise.race([
+          this.driver.run(sample, { timeout: timeoutMs, signal: controller.signal }),
+          timeoutPromise,
+        ]);
+      } finally {
+        if (timeoutHandle) clearTimeout(timeoutHandle);
+      }
+
+      let scores: Score[];
+      try {
+        scores = gradeEvalCase(observed, sample.expected);
+      } catch (graderErr) {
+        const msg = graderErr instanceof Error ? graderErr.message : String(graderErr);
+        scores = [
+          {
+            name: "grader-error",
+            value: 0,
+            pass: false,
+            reason: `grader threw: ${msg}`,
+          },
+        ];
+      }
+      const allPass = scores.length === 0 || scores.every((s) => s.pass);
+      return {
+        caseId: sample.id,
+        pass: allPass,
+        scores,
+        observed,
+        durationMs: Date.now() - start,
+      };
+    } catch (error: unknown) {
+      // Make sure we abort any in-flight driver work even if the failure path
+      // wasn't the timeout itself (e.g. driver threw synchronously).
+      if (!controller.signal.aborted) controller.abort();
+      const message = error instanceof Error ? error.message : String(error);
+      const stack = error instanceof Error && error.stack ? "\n" + error.stack : "";
+      return {
+        caseId: sample.id,
+        pass: false,
+        scores: [],
+        observed: {
+          toolCalls: [],
+          finalResponse: "",
+          sessionId: "",
+          latencyMs: 0,
+        },
+        infraError: message + stack,
+        durationMs: Date.now() - start,
+      };
+    }
+  }
+
+  checkPassRateFloor(result: RunResult, floor: number): boolean {
+    return result.summary.passRate >= floor;
+  }
+}

--- a/packages/eval-harness/src/types.ts
+++ b/packages/eval-harness/src/types.ts
@@ -1,0 +1,145 @@
+import { z } from "zod";
+
+export const EvalToolCallSchema = z.object({
+  name: z.string().min(1),
+  args: z.record(z.string(), z.unknown()).optional(),
+  match: z.enum(["exact", "subset", "fuzzy", "setEquals"]).default("subset"),
+  order: z.number().int().optional(),
+});
+export type EvalToolCall = z.infer<typeof EvalToolCallSchema>;
+
+export const EvalExpectedSchema = z
+  .object({
+    toolCalls: z.array(EvalToolCallSchema).optional(),
+    toolSequence: z.enum(["strict", "unordered"]).default("unordered"),
+    forbiddenTools: z.array(z.string()).optional(),
+    minCalls: z.number().int().nonnegative().optional(),
+    maxCalls: z.number().int().nonnegative().optional(),
+    noToolCall: z.boolean().optional(),
+    response: z
+      .object({
+        containsAny: z.array(z.string()).optional(),
+        containsAll: z.array(z.string()).optional(),
+      })
+      .optional(),
+    cms: z
+      .object({
+        stateIn: z.array(z.string()).optional(),
+      })
+      .optional(),
+  })
+  .superRefine((val, ctx) => {
+    if (val.noToolCall === true && val.toolCalls && val.toolCalls.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "noToolCall=true cannot be combined with non-empty toolCalls",
+        path: ["noToolCall"],
+      });
+    }
+    if (
+      typeof val.minCalls === "number" &&
+      typeof val.maxCalls === "number" &&
+      val.minCalls > val.maxCalls
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `minCalls (${val.minCalls}) must be <= maxCalls (${val.maxCalls})`,
+        path: ["minCalls"],
+      });
+    }
+  });
+export type EvalExpected = z.infer<typeof EvalExpectedSchema>;
+
+export const EvalContextMessageSchema = z.object({
+  role: z.enum(["user", "assistant"]),
+  content: z.string(),
+});
+
+export const EvalSampleInputSchema = z.object({
+  prompt: z.string(),
+  systemMessage: z.string().optional(),
+  context: z.array(EvalContextMessageSchema).optional(),
+});
+
+export const EvalSampleSchema = z.object({
+  id: z.string().min(1),
+  description: z.string(),
+  input: EvalSampleInputSchema,
+  expected: EvalExpectedSchema,
+  tools: z.array(z.string()).optional(),
+  tags: z.array(z.string()).optional(),
+  timeoutMs: z.number().int().positive().default(120000),
+});
+export type EvalSample = z.infer<typeof EvalSampleSchema>;
+
+export const EvalTaskSchema = z.object({
+  schemaVersion: z.literal(1),
+  id: z.string().min(1),
+  name: z.string().min(1),
+  description: z.string(),
+  version: z.string().min(1),
+  passRateFloor: z.number().min(0).max(1).optional(),
+  samples: z.array(EvalSampleSchema).min(1),
+});
+export type EvalTask = z.infer<typeof EvalTaskSchema>;
+
+export const ScoreSchema = z.object({
+  name: z.string(),
+  value: z.number().min(0).max(1),
+  pass: z.boolean(),
+  reason: z.string(),
+  actual: z.unknown().optional(),
+  expected: z.unknown().optional(),
+});
+export type Score = z.infer<typeof ScoreSchema>;
+
+export const ObservedToolCallSchema = z.object({
+  name: z.string(),
+  args: z.record(z.string(), z.unknown()),
+  result: z.unknown().optional(),
+  timestamp: z.number().optional(),
+  order: z.number().int().nonnegative(),
+});
+export type ObservedToolCall = z.infer<typeof ObservedToolCallSchema>;
+
+export const ObservedResultSchema = z.object({
+  toolCalls: z.array(ObservedToolCallSchema),
+  finalResponse: z.string(),
+  sessionId: z.string(),
+  model: z.string().optional(),
+  latencyMs: z.number().nonnegative(),
+  cmsState: z.string().optional(),
+});
+export type ObservedResult = z.infer<typeof ObservedResultSchema>;
+
+export const CaseResultSchema = z.object({
+  caseId: z.string(),
+  pass: z.boolean(),
+  scores: z.array(ScoreSchema),
+  observed: ObservedResultSchema,
+  infraError: z.string().optional(),
+  durationMs: z.number().nonnegative(),
+});
+export type CaseResult = z.infer<typeof CaseResultSchema>;
+
+export const RunSummarySchema = z.object({
+  total: z.number().int().nonnegative(),
+  passed: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  errored: z.number().int().nonnegative(),
+  passRate: z.number().min(0).max(1),
+});
+
+export const RunResultSchema = z.object({
+  schemaVersion: z.literal(1),
+  runId: z.string(),
+  taskId: z.string(),
+  taskVersion: z.string(),
+  gitSha: z.string().optional(),
+  model: z.string().optional(),
+  startedAt: z.string(),
+  finishedAt: z.string(),
+  summary: RunSummarySchema,
+  cases: z.array(CaseResultSchema),
+});
+export type RunResult = z.infer<typeof RunResultSchema>;

--- a/packages/eval-harness/test/cms-state.test.ts
+++ b/packages/eval-harness/test/cms-state.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { gradeCmsState } from "../src/graders/cms-state.js";
+
+describe("gradeCmsState", () => {
+  it("state in list → pass", () => {
+    const s = gradeCmsState("idle", { stateIn: ["idle", "running"] });
+    expect(s).toBeDefined();
+    expect(s!.pass).toBe(true);
+    expect(s!.value).toBe(1);
+  });
+
+  it("state not in list → fail", () => {
+    const s = gradeCmsState("errored", { stateIn: ["idle", "running"] });
+    expect(s!.pass).toBe(false);
+    expect(s!.value).toBe(0);
+  });
+
+  it("undefined stateIn → returns undefined (skip)", () => {
+    const s = gradeCmsState("idle", {});
+    expect(s).toBeUndefined();
+  });
+
+  it("undefined actual state → fail", () => {
+    const s = gradeCmsState(undefined, { stateIn: ["idle"] });
+    expect(s!.pass).toBe(false);
+  });
+});

--- a/packages/eval-harness/test/eval-core.test.ts
+++ b/packages/eval-harness/test/eval-core.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadEvalTask } from "../src/loader.js";
+import { EvalRunner } from "../src/runner.js";
+import { FakeDriver } from "../src/drivers/fake-driver.js";
+import { ConsoleReporter } from "../src/reporters/console.js";
+import type { ObservedResult } from "../src/types.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const task = loadEvalTask(
+  resolve(__dirname, "../datasets/tool-call-correctness.v1.json"),
+);
+
+const fakeScenarios: Record<string, ObservedResult> = {
+  "single.add.basic": {
+    toolCalls: [
+      { name: "test_add", args: { a: 17, b: 25 }, result: { result: 42 }, order: 0 },
+    ],
+    finalResponse: "The result of 17 + 25 is 42.",
+    sessionId: "fake-session-1",
+    latencyMs: 100,
+    cmsState: "idle",
+  },
+  "single.weather.multi-param": {
+    toolCalls: [
+      { name: "test_weather", args: { city: "Tokyo" }, result: { temperature: 72 }, order: 0 },
+    ],
+    finalResponse: "The weather in Tokyo is 72°F and sunny.",
+    sessionId: "fake-session-2",
+    latencyMs: 100,
+    cmsState: "idle",
+  },
+  "selection.multiply-not-add": {
+    toolCalls: [
+      { name: "test_multiply", args: { a: 4, b: 5 }, result: { result: 20 }, order: 0 },
+    ],
+    finalResponse: "4 times 5 is 20.",
+    sessionId: "fake-session-3",
+    latencyMs: 100,
+    cmsState: "idle",
+  },
+  "selection.no-tool-with-tools": {
+    toolCalls: [],
+    finalResponse: "Hello! How can I help you today?",
+    sessionId: "fake-session-4",
+    latencyMs: 50,
+    cmsState: "idle",
+  },
+  "sequence.add-then-multiply": {
+    toolCalls: [
+      { name: "test_add", args: { a: 2, b: 3 }, result: { result: 5 }, order: 0 },
+      { name: "test_multiply", args: { a: 4, b: 5 }, result: { result: 20 }, order: 1 },
+    ],
+    finalResponse: "2+3=5 and 4×5=20.",
+    sessionId: "fake-session-5",
+    latencyMs: 200,
+    cmsState: "idle",
+  },
+  "multi.unordered-weather": {
+    toolCalls: [
+      { name: "test_weather", args: { city: "Tokyo" }, result: { temperature: 72 }, order: 0 },
+      { name: "test_weather", args: { city: "London" }, result: { temperature: 55 }, order: 1 },
+    ],
+    finalResponse: "Tokyo: 72°F, London: 55°F.",
+    sessionId: "fake-session-6",
+    latencyMs: 150,
+    cmsState: "idle",
+  },
+};
+
+describe("eval:tool-call-correctness", () => {
+  const driver = FakeDriver.fromMap(fakeScenarios);
+  const runner = new EvalRunner({ driver, reporters: [new ConsoleReporter()] });
+
+  it("loads golden dataset successfully", () => {
+    expect(task.samples).toHaveLength(6);
+    expect(task.schemaVersion).toBe(1);
+  });
+
+  it("all fake scenarios pass harness grading", async () => {
+    const result = await runner.runTask(task);
+    expect(result.summary.passed).toBe(6);
+    expect(result.summary.failed).toBe(0);
+    expect(result.summary.errored).toBe(0);
+    expect(result.summary.passRate).toBe(1);
+  });
+
+  it("passes passRateFloor check", async () => {
+    const result = await runner.runTask(task);
+    expect(runner.checkPassRateFloor(result, task.passRateFloor ?? 0.8)).toBe(true);
+  });
+
+  for (const sample of task.samples) {
+    it(`case: ${sample.id}`, async () => {
+      const singleTask = { ...task, samples: [sample] };
+      const result = await runner.runTask(singleTask);
+      if (!result.cases[0].pass) {
+        const failures = result.cases[0].scores.filter((s) => !s.pass);
+        console.error(`Failed scores for ${sample.id}:`, failures);
+      }
+      expect(result.cases[0].pass).toBe(true);
+    });
+  }
+});

--- a/packages/eval-harness/test/eval-tools.test.ts
+++ b/packages/eval-harness/test/eval-tools.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import {
+  createEvalToolTracker,
+  createEvalAddTool,
+  createEvalMultiplyTool,
+  createEvalWeatherTool,
+} from "../src/fixtures/eval-tools.js";
+
+describe("EvalToolTracker", () => {
+  it("starts with empty invocations", () => {
+    const { tracker } = createEvalToolTracker();
+    expect(tracker.invocations).toEqual([]);
+  });
+
+  it("records all invocations in order across tools", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.add.handler({ a: 1, b: 2 });
+    await tools.multiply.handler({ a: 3, b: 4 });
+    await tools.add.handler({ a: 5, b: 6 });
+
+    expect(tracker.invocations.length).toBe(3);
+    expect(tracker.invocations[0].name).toBe("test_add");
+    expect(tracker.invocations[0].args).toEqual({ a: 1, b: 2 });
+    expect(tracker.invocations[0].order).toBe(0);
+    expect(tracker.invocations[1].name).toBe("test_multiply");
+    expect(tracker.invocations[1].order).toBe(1);
+    expect(tracker.invocations[2].name).toBe("test_add");
+    expect(tracker.invocations[2].args).toEqual({ a: 5, b: 6 });
+    expect(tracker.invocations[2].order).toBe(2);
+  });
+
+  it("records results of each invocation", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.add.handler({ a: 2, b: 3 });
+    expect(tracker.invocations[0].result).toEqual({ result: 5 });
+  });
+
+  it("records a timestamp for each invocation", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    const before = Date.now();
+    await tools.add.handler({ a: 1, b: 1 });
+    const after = Date.now();
+    const ts = tracker.invocations[0].timestamp;
+    expect(typeof ts).toBe("number");
+    expect(ts).toBeGreaterThanOrEqual(before);
+    expect(ts).toBeLessThanOrEqual(after);
+  });
+
+  it("reset() clears history", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.add.handler({ a: 1, b: 2 });
+    expect(tracker.invocations.length).toBe(1);
+    tracker.reset();
+    expect(tracker.invocations).toEqual([]);
+  });
+
+  it("reset() restarts order from 0", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.add.handler({ a: 1, b: 2 });
+    tracker.reset();
+    await tools.add.handler({ a: 9, b: 9 });
+    expect(tracker.invocations[0].order).toBe(0);
+  });
+
+  it("records multiple calls to the same tool", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.add.handler({ a: 1, b: 1 });
+    await tools.add.handler({ a: 2, b: 2 });
+    await tools.add.handler({ a: 3, b: 3 });
+    expect(tracker.invocations.length).toBe(3);
+    expect(tracker.invocations.map((i) => i.result)).toEqual([
+      { result: 2 },
+      { result: 4 },
+      { result: 6 },
+    ]);
+  });
+});
+
+describe("createEvalAddTool / createEvalMultiplyTool", () => {
+  it("standalone factories share tracker state", async () => {
+    const { tracker } = createEvalToolTracker();
+    const add = createEvalAddTool(tracker);
+    const mul = createEvalMultiplyTool(tracker);
+    await add.handler({ a: 1, b: 2 });
+    await mul.handler({ a: 3, b: 4 });
+    expect(tracker.invocations.length).toBe(2);
+    expect(tracker.invocations[0].name).toBe("test_add");
+    expect(tracker.invocations[1].name).toBe("test_multiply");
+  });
+
+  it("add tool name is 'test_add' and multiply is 'test_multiply'", () => {
+    const { tracker } = createEvalToolTracker();
+    const add = createEvalAddTool(tracker);
+    const mul = createEvalMultiplyTool(tracker);
+    expect(add.name).toBe("test_add");
+    expect(mul.name).toBe("test_multiply");
+  });
+});
+
+describe("createEvalWeatherTool", () => {
+  it("accepts optional unit parameter", async () => {
+    const { tracker } = createEvalToolTracker();
+    const weather = createEvalWeatherTool(tracker);
+    const result = await weather.handler({ city: "Seattle", unit: "celsius" });
+    expect(tracker.invocations[0].args).toEqual({ city: "Seattle", unit: "celsius" });
+    expect(result).toMatchObject({ city: "Seattle", unit: "celsius" });
+  });
+
+  it("defaults unit to 'fahrenheit' when omitted", async () => {
+    const { tracker } = createEvalToolTracker();
+    const weather = createEvalWeatherTool(tracker);
+    const result = await weather.handler({ city: "Seattle" });
+    expect(result).toMatchObject({ city: "Seattle", unit: "fahrenheit" });
+  });
+
+  it("exposes 'unit' in the tool parameter schema as optional", () => {
+    const { tracker } = createEvalToolTracker();
+    const weather = createEvalWeatherTool(tracker);
+    const params = weather.parameters as {
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+    expect(params.properties).toHaveProperty("unit");
+    expect(params.properties).toHaveProperty("city");
+    expect(params.required).toContain("city");
+    expect(params.required ?? []).not.toContain("unit");
+  });
+
+  it("records weather invocations in tracker", async () => {
+    const { tracker, tools } = createEvalToolTracker();
+    await tools.weather.handler({ city: "Austin" });
+    await tools.weather.handler({ city: "NYC", unit: "celsius" });
+    expect(tracker.invocations.length).toBe(2);
+    expect(tracker.invocations[0].name).toBe("test_weather");
+    expect(tracker.invocations[0].args).toEqual({ city: "Austin" });
+    expect(tracker.invocations[1].args).toEqual({ city: "NYC", unit: "celsius" });
+  });
+});

--- a/packages/eval-harness/test/fake-driver.test.ts
+++ b/packages/eval-harness/test/fake-driver.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import { FakeDriver } from "../src/drivers/fake-driver.js";
+import type { Driver } from "../src/drivers/types.js";
+import type { EvalSample, ObservedResult } from "../src/types.js";
+import { ObservedResultSchema } from "../src/types.js";
+
+function makeSample(id: string, prompt = "hello"): EvalSample {
+  return {
+    id,
+    description: `sample ${id}`,
+    input: { prompt },
+    expected: { toolSequence: "unordered" },
+    timeoutMs: 120_000,
+  };
+}
+
+function makeResult(overrides: Partial<ObservedResult> = {}): ObservedResult {
+  return {
+    toolCalls: [],
+    finalResponse: "ok",
+    sessionId: "sess-1",
+    latencyMs: 10,
+    ...overrides,
+  };
+}
+
+describe("FakeDriver", () => {
+  it("returns pre-configured response for matching sampleId", async () => {
+    const response = makeResult({ finalResponse: "hello world", sessionId: "s-1" });
+    const driver = new FakeDriver([{ sampleId: "sample-a", response }]);
+    const result = await driver.run(makeSample("sample-a"));
+    expect(result.finalResponse).toBe("hello world");
+    expect(result.sessionId).toBe("s-1");
+  });
+
+  it("throws error for unknown sampleId", async () => {
+    const driver = new FakeDriver([{ sampleId: "known", response: makeResult() }]);
+    await expect(driver.run(makeSample("unknown"))).rejects.toThrow(/unknown/i);
+  });
+
+  it("FakeDriver.fromMap() creates driver from record", async () => {
+    const driver = FakeDriver.fromMap({
+      "s-1": makeResult({ finalResponse: "r1" }),
+      "s-2": makeResult({ finalResponse: "r2" }),
+    });
+    expect(await (await driver.run(makeSample("s-1"))).finalResponse).toBe("r1");
+    expect((await driver.run(makeSample("s-2"))).finalResponse).toBe("r2");
+  });
+
+  it("returns correct tool calls from scenario", async () => {
+    const response = makeResult({
+      toolCalls: [
+        { name: "test_add", args: { a: 1, b: 2 }, result: { result: 3 }, order: 0 },
+      ],
+    });
+    const driver = new FakeDriver([{ sampleId: "sid", response }]);
+    const result = await driver.run(makeSample("sid"));
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].name).toBe("test_add");
+    expect(result.toolCalls[0].args).toEqual({ a: 1, b: 2 });
+  });
+
+  it("returns correct final response", async () => {
+    const driver = new FakeDriver([
+      { sampleId: "x", response: makeResult({ finalResponse: "the final answer is 42" }) },
+    ]);
+    const result = await driver.run(makeSample("x"));
+    expect(result.finalResponse).toBe("the final answer is 42");
+  });
+
+  it("returns correct sessionId", async () => {
+    const driver = new FakeDriver([
+      { sampleId: "x", response: makeResult({ sessionId: "session-abc" }) },
+    ]);
+    const result = await driver.run(makeSample("x"));
+    expect(result.sessionId).toBe("session-abc");
+  });
+
+  it("multiple scenarios each return its own response", async () => {
+    const driver = new FakeDriver([
+      { sampleId: "a", response: makeResult({ finalResponse: "A" }) },
+      { sampleId: "b", response: makeResult({ finalResponse: "B" }) },
+      { sampleId: "c", response: makeResult({ finalResponse: "C" }) },
+    ]);
+    expect((await driver.run(makeSample("a"))).finalResponse).toBe("A");
+    expect((await driver.run(makeSample("b"))).finalResponse).toBe("B");
+    expect((await driver.run(makeSample("c"))).finalResponse).toBe("C");
+  });
+
+  it("implements Driver interface (run method exists)", () => {
+    const driver: Driver = new FakeDriver([]);
+    expect(typeof driver.run).toBe("function");
+  });
+
+  it("ObservedResult shape validates against schema", async () => {
+    const driver = new FakeDriver([
+      {
+        sampleId: "s",
+        response: makeResult({
+          toolCalls: [{ name: "t", args: {}, order: 0 }],
+          finalResponse: "done",
+          sessionId: "sess",
+          latencyMs: 5,
+        }),
+      },
+    ]);
+    const result = await driver.run(makeSample("s"));
+    expect(() => ObservedResultSchema.parse(result)).not.toThrow();
+  });
+
+  it("simulates small latency (non-negative latencyMs)", async () => {
+    const driver = new FakeDriver([
+      { sampleId: "s", response: makeResult({ latencyMs: 1 }) },
+    ]);
+    const result = await driver.run(makeSample("s"));
+    expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it("returns distinct objects for repeated calls to same sampleId (no mutation leak)", async () => {
+    const stored = makeResult({
+      finalResponse: "original",
+      toolCalls: [{ name: "test_add", args: { a: 1 }, order: 0 }],
+    });
+    const driver = new FakeDriver([{ sampleId: "s", response: stored }]);
+
+    const r1 = await driver.run(makeSample("s"));
+    const r2 = await driver.run(makeSample("s"));
+
+    expect(r1).not.toBe(r2);
+    expect(r1.toolCalls).not.toBe(r2.toolCalls);
+
+    // mutate r1; r2 must remain unaffected
+    r1.finalResponse = "mutated";
+    (r1.toolCalls[0].args as Record<string, unknown>).a = 999;
+
+    expect(r2.finalResponse).toBe("original");
+    expect(r2.toolCalls[0].args).toEqual({ a: 1 });
+
+    // Stored scenario also unaffected for future runs
+    const r3 = await driver.run(makeSample("s"));
+    expect(r3.finalResponse).toBe("original");
+    expect(r3.toolCalls[0].args).toEqual({ a: 1 });
+  });
+});

--- a/packages/eval-harness/test/fixtures/test-fixture.json
+++ b/packages/eval-harness/test/fixtures/test-fixture.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "id": "test-fixture",
+  "name": "Test Fixture",
+  "description": "A fixture for testing the loader",
+  "version": "1.0.0",
+  "samples": [
+    {
+      "id": "test.sample.1",
+      "description": "Test sample",
+      "input": { "prompt": "Add 2 and 3" },
+      "expected": {
+        "toolCalls": [{ "name": "test_add", "args": { "a": 2, "b": 3 } }]
+      },
+      "tools": ["test_add"]
+    }
+  ]
+}

--- a/packages/eval-harness/test/fixtures/test-invalid.json
+++ b/packages/eval-harness/test/fixtures/test-invalid.json
@@ -1,0 +1,1 @@
+{ "schemaVersion": 2, "name": "bad" }

--- a/packages/eval-harness/test/fixtures/valid-dir/README.md
+++ b/packages/eval-harness/test/fixtures/valid-dir/README.md
@@ -1,0 +1,1 @@
+not a json file

--- a/packages/eval-harness/test/fixtures/valid-dir/a.json
+++ b/packages/eval-harness/test/fixtures/valid-dir/a.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "id": "valid-a",
+  "name": "Valid A",
+  "description": "First valid fixture in dir",
+  "version": "1.0.0",
+  "samples": [
+    {
+      "id": "valid-a.1",
+      "description": "a sample",
+      "input": { "prompt": "hello" },
+      "expected": { "toolCalls": [{ "name": "t" }] }
+    }
+  ]
+}

--- a/packages/eval-harness/test/fixtures/valid-dir/b.json
+++ b/packages/eval-harness/test/fixtures/valid-dir/b.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 1,
+  "id": "valid-b",
+  "name": "Valid B",
+  "description": "Second valid fixture in dir",
+  "version": "2.0.0",
+  "samples": [
+    {
+      "id": "valid-b.1",
+      "description": "another sample",
+      "input": { "prompt": "world" },
+      "expected": { "toolCalls": [{ "name": "u" }] }
+    }
+  ]
+}

--- a/packages/eval-harness/test/graders-index.test.ts
+++ b/packages/eval-harness/test/graders-index.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from "vitest";
+import { gradeEvalCase } from "../src/graders/index.js";
+import type { ObservedResult, EvalExpected } from "../src/types.js";
+
+function mkObserved(overrides: Partial<ObservedResult> = {}): ObservedResult {
+  return {
+    toolCalls: [],
+    finalResponse: "",
+    sessionId: "s1",
+    latencyMs: 0,
+    ...overrides,
+  };
+}
+
+describe("gradeEvalCase", () => {
+  it("full case with tool calls + response + CMS → multiple scores returned", () => {
+    const observed = mkObserved({
+      toolCalls: [{ name: "add", args: { a: 1, b: 2 }, order: 0 }],
+      finalResponse: "The sum is 3",
+      cmsState: "idle",
+    });
+    const expected: EvalExpected = {
+      toolCalls: [{ name: "add", args: { a: 1, b: 2 }, match: "subset" }],
+      toolSequence: "unordered",
+      response: { containsAll: ["3"] },
+      cms: { stateIn: ["idle"] },
+    };
+    const scores = gradeEvalCase(observed, expected);
+    expect(scores.length).toBeGreaterThan(1);
+    expect(scores.some((s) => s.name === "tool-names")).toBe(true);
+    expect(scores.some((s) => s.name === "response-contains")).toBe(true);
+    expect(scores.some((s) => s.name === "cms-state")).toBe(true);
+  });
+
+  it("no tool expectations → tool graders skipped (but forbidden/call-count can still apply if set)", () => {
+    const observed = mkObserved({ finalResponse: "hi" });
+    const expected: EvalExpected = {
+      toolSequence: "unordered",
+      response: { containsAll: ["hi"] },
+    };
+    const scores = gradeEvalCase(observed, expected);
+    expect(scores.some((s) => s.name === "tool-names")).toBe(false);
+    expect(scores.some((s) => s.name === "response-contains")).toBe(true);
+  });
+
+  it("no response expectations → response grader skipped", () => {
+    const observed = mkObserved({
+      toolCalls: [{ name: "add", args: {}, order: 0 }],
+    });
+    const expected: EvalExpected = {
+      toolCalls: [{ name: "add", match: "subset" }],
+      toolSequence: "unordered",
+    };
+    const scores = gradeEvalCase(observed, expected);
+    expect(scores.some((s) => s.name === "response-contains")).toBe(false);
+  });
+
+  it("all passing → all scores pass", () => {
+    const observed = mkObserved({
+      toolCalls: [{ name: "add", args: { a: 1, b: 2 }, order: 0 }],
+      finalResponse: "result 3",
+      cmsState: "idle",
+    });
+    const expected: EvalExpected = {
+      toolCalls: [{ name: "add", args: { a: 1, b: 2 }, match: "subset" }],
+      toolSequence: "strict",
+      response: { containsAll: ["3"] },
+      cms: { stateIn: ["idle"] },
+    };
+    const scores = gradeEvalCase(observed, expected);
+    expect(scores.every((s) => s.pass)).toBe(true);
+  });
+
+  it("mixed results → correct pass/fail per score", () => {
+    const observed = mkObserved({
+      toolCalls: [{ name: "multiply", args: {}, order: 0 }],
+      finalResponse: "wrong",
+      cmsState: "errored",
+    });
+    const expected: EvalExpected = {
+      toolCalls: [{ name: "add", match: "subset" }],
+      toolSequence: "unordered",
+      response: { containsAll: ["right"] },
+      cms: { stateIn: ["idle"] },
+    };
+    const scores = gradeEvalCase(observed, expected);
+    expect(scores.every((s) => !s.pass)).toBe(true);
+  });
+
+  it("matches expected tool calls to distinct observed calls (no double-counting)", () => {
+    // Two expected calls to test_weather with different args.
+    // Only one observed call. The same observed call must NOT satisfy both expectations.
+    const observed = mkObserved({
+      toolCalls: [{ name: "test_weather", args: { city: "Paris" }, order: 0 }],
+    });
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "test_weather", args: { city: "Paris" }, match: "subset" },
+        { name: "test_weather", args: { city: "London" }, match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeEvalCase(observed, expected);
+    const argScores = scores.filter((s) => s.name === "tool-args:test_weather");
+    expect(argScores).toHaveLength(2);
+    // Exactly one should pass (Paris), the other should fail (London missing — no observed call left).
+    const passCount = argScores.filter((s) => s.pass).length;
+    expect(passCount).toBe(1);
+  });
+
+  it("matches most-constrained expectations first to avoid mis-pairing duplicates", () => {
+    // Two observed calls to the same tool, one with extra args.
+    // A naive greedy match (in declaration order) would pair the less-specific
+    // expected call with the more-specific observed call, then fail to match
+    // the more-specific expected call against what's left. Sorting expected by
+    // arg-count descending fixes this.
+    const observed = mkObserved({
+      toolCalls: [
+        { name: "f", args: { a: 1 }, order: 0 },
+        { name: "f", args: { a: 1, b: 2 }, order: 1 },
+      ],
+    });
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "f", args: { a: 1 }, match: "subset" },
+        { name: "f", args: { a: 1, b: 2 }, match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeEvalCase(observed, expected);
+    const argScores = scores.filter((s) => s.name.startsWith("tool-args:f"));
+    expect(argScores).toHaveLength(2);
+    expect(argScores.every((s) => s.pass)).toBe(true);
+  });
+});

--- a/packages/eval-harness/test/live-driver.test.ts
+++ b/packages/eval-harness/test/live-driver.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import { LiveDriver } from "../src/drivers/live-driver.js";
+import type { Driver, DriverOptions } from "../src/drivers/types.js";
+import type { EvalSample } from "../src/types.js";
+
+describe("LiveDriver", () => {
+  it("implements Driver interface", () => {
+    const driver: Driver = new LiveDriver();
+    expect(typeof driver.run).toBe("function");
+  });
+
+  it("constructor accepts options", () => {
+    const options: DriverOptions = { model: "gpt-4", timeout: 30_000 };
+    const driver = new LiveDriver(options);
+    expect(driver).toBeInstanceOf(LiveDriver);
+  });
+
+  it("run method is async (returns a Promise)", () => {
+    const driver = new LiveDriver();
+    expect(typeof driver.run).toBe("function");
+    expect(driver.run.constructor.name).toBe("AsyncFunction");
+  });
+});
+
+describe("LiveDriver: validation", () => {
+  function makeSample(overrides: Partial<EvalSample> = {}): EvalSample {
+    return {
+      id: "s1",
+      description: "test",
+      input: { prompt: "hi" },
+      expected: { toolSequence: "unordered" },
+      timeoutMs: 60_000,
+      ...overrides,
+    };
+  }
+
+  it("throws when sample has context messages", async () => {
+    const driver = new LiveDriver();
+    const sample = makeSample({
+      input: {
+        prompt: "follow up",
+        context: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "hello" },
+        ],
+      },
+    });
+    await expect(driver.run(sample)).rejects.toThrow(/context/i);
+  });
+
+  it("throws on unknown tool name", async () => {
+    const driver = new LiveDriver();
+    const sample = makeSample({ tools: ["test_add", "definitely_not_a_tool"] });
+    await expect(driver.run(sample)).rejects.toThrow(/definitely_not_a_tool/);
+  });
+});
+
+describe("LiveDriver: lifecycle / cleanup", () => {
+  function makeSample(overrides: Partial<EvalSample> = {}): EvalSample {
+    return {
+      id: "leak-test",
+      description: "leak",
+      input: { prompt: "hi" },
+      expected: { toolSequence: "unordered" },
+      timeoutMs: 60_000,
+      ...overrides,
+    };
+  }
+
+  function fakeEnv() {
+    return {
+      cleanup: vi.fn().mockResolvedValue(undefined),
+      store: "postgresql://fake/none",
+      duroxideSchema: "d",
+      cmsSchema: "c",
+      factsSchema: "f",
+      sessionStateDir: "/tmp/never-used",
+    };
+  }
+
+  it("cleans up env when worker.start fails", async () => {
+    const env = fakeEnv();
+    class FailingWorker {
+      registerTools() {}
+      setSessionConfig() {}
+      async start() {
+        throw new Error("worker boom");
+      }
+      async stop() {}
+    }
+    class NoopClient {
+      async start() {}
+      async stop() {}
+      async createSession() {
+        return { sessionId: "x", sendAndWait: async () => "", getInfo: async () => null };
+      }
+    }
+    const driver = new LiveDriver(undefined, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createEnv: () => env as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      WorkerCtor: FailingWorker as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ClientCtor: NoopClient as any,
+    });
+    await expect(driver.run(makeSample())).rejects.toThrow(/worker boom/);
+    expect(env.cleanup).toHaveBeenCalled();
+  });
+
+  it("cleans up env + stops worker when client.start fails", async () => {
+    const env = fakeEnv();
+    const workerStop = vi.fn().mockResolvedValue(undefined);
+    class OkWorker {
+      registerTools() {}
+      setSessionConfig() {}
+      async start() {}
+      stop = workerStop;
+    }
+    class FailingClient {
+      async start() {
+        throw new Error("client boom");
+      }
+      async stop() {}
+      async createSession() {
+        return { sessionId: "x", sendAndWait: async () => "", getInfo: async () => null };
+      }
+    }
+    const driver = new LiveDriver(undefined, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createEnv: () => env as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      WorkerCtor: OkWorker as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ClientCtor: FailingClient as any,
+    });
+    await expect(driver.run(makeSample())).rejects.toThrow(/client boom/);
+    expect(workerStop).toHaveBeenCalled();
+    expect(env.cleanup).toHaveBeenCalled();
+  });
+
+  it("uses a unique workerNodeId per run", async () => {
+    const env = fakeEnv();
+    const workerConfigs: Array<Record<string, unknown>> = [];
+    class CapturingWorker {
+      constructor(cfg: Record<string, unknown>) {
+        workerConfigs.push(cfg);
+      }
+      registerTools() {}
+      setSessionConfig() {}
+      async start() {
+        throw new Error("stop early");
+      }
+      async stop() {}
+    }
+    class NoopClient {
+      async start() {}
+      async stop() {}
+      async createSession() {
+        return { sessionId: "x", sendAndWait: async () => "", getInfo: async () => null };
+      }
+    }
+    const driver = new LiveDriver(undefined, {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createEnv: () => env as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      WorkerCtor: CapturingWorker as any,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ClientCtor: NoopClient as any,
+    });
+    await expect(driver.run(makeSample({ id: "a" }))).rejects.toThrow();
+    await expect(driver.run(makeSample({ id: "b" }))).rejects.toThrow();
+    expect(workerConfigs).toHaveLength(2);
+    expect(workerConfigs[0].workerNodeId).not.toBe(workerConfigs[1].workerNodeId);
+    expect(String(workerConfigs[0].workerNodeId)).toMatch(/^eval-/);
+  });
+});

--- a/packages/eval-harness/test/loader.test.ts
+++ b/packages/eval-harness/test/loader.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadEvalTask, loadEvalTaskFromDir } from "../src/loader.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURES = resolve(__dirname, "fixtures");
+
+describe("loadEvalTask", () => {
+  it("loads a valid JSON fixture file and returns an EvalTask", () => {
+    const task = loadEvalTask(resolve(FIXTURES, "test-fixture.json"));
+    expect(task.id).toBe("test-fixture");
+    expect(task.name).toBe("Test Fixture");
+    expect(task.version).toBe("1.0.0");
+    expect(task.samples).toHaveLength(1);
+    expect(task.samples[0].id).toBe("test.sample.1");
+  });
+
+  it("validates with zod and applies default values (match defaults to subset)", () => {
+    const task = loadEvalTask(resolve(FIXTURES, "test-fixture.json"));
+    // match default
+    expect(task.samples[0].expected.toolCalls?.[0].match).toBe("subset");
+    // toolSequence default
+    expect(task.samples[0].expected.toolSequence).toBe("unordered");
+    // timeoutMs default
+    expect(task.samples[0].timeoutMs).toBe(120000);
+  });
+
+  it("throws on missing required fields", () => {
+    expect(() => loadEvalTask(resolve(FIXTURES, "test-invalid.json"))).toThrow();
+  });
+
+  it("throws on invalid schemaVersion", () => {
+    // test-invalid.json has schemaVersion: 2
+    expect(() => loadEvalTask(resolve(FIXTURES, "test-invalid.json"))).toThrow(
+      /schemaVersion|invalid/i,
+    );
+  });
+
+  it("throws on file not found", () => {
+    expect(() => loadEvalTask(resolve(FIXTURES, "does-not-exist.json"))).toThrow();
+  });
+});
+
+describe("loadEvalTaskFromDir", () => {
+  it("loads all JSON files in the directory", () => {
+    const tasks = loadEvalTaskFromDir(resolve(FIXTURES, "valid-dir"));
+    expect(tasks).toHaveLength(2);
+    const ids = tasks.map((t) => t.id).sort();
+    expect(ids).toEqual(["valid-a", "valid-b"]);
+  });
+
+  it("skips non-JSON files (e.g., README.md)", () => {
+    const tasks = loadEvalTaskFromDir(resolve(FIXTURES, "valid-dir"));
+    // All results should be validated EvalTask objects
+    for (const task of tasks) {
+      expect(task.schemaVersion).toBe(1);
+      expect(typeof task.id).toBe("string");
+    }
+  });
+
+  it("returns an empty array for a directory with no JSON files", () => {
+    // Use __tests__ itself which has no top-level JSON files
+    // Actually, __tests__ has no JSON at root (fixtures/ is a subdir). Let's verify.
+    // Use the node_modules-less approach: point at a known empty-of-json dir.
+    // Since our loader should not recurse, pointing at __tests__ root dir should yield 0
+    // provided we only check the immediate directory.
+    const tasks = loadEvalTaskFromDir(__dirname);
+    // __dirname = .../__tests__ — contains .ts files only, no .json at that level.
+    expect(tasks).toEqual([]);
+  });
+});

--- a/packages/eval-harness/test/match-args.test.ts
+++ b/packages/eval-harness/test/match-args.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest";
+import { matchArgs, sortKeys } from "../src/graders/match-args.js";
+
+describe("sortKeys", () => {
+  it("sorts top-level keys alphabetically", () => {
+    const result = sortKeys({ b: 1, a: 2, c: 3 });
+    expect(Object.keys(result as Record<string, unknown>)).toEqual(["a", "b", "c"]);
+  });
+
+  it("recursively sorts nested object keys", () => {
+    const result = sortKeys({ b: { z: 1, a: 2 }, a: 1 }) as Record<string, Record<string, number>>;
+    expect(Object.keys(result)).toEqual(["a", "b"]);
+    expect(Object.keys(result.b)).toEqual(["a", "z"]);
+  });
+
+  it("passes through primitives unchanged", () => {
+    expect(sortKeys(42)).toBe(42);
+    expect(sortKeys("hi")).toBe("hi");
+    expect(sortKeys(null)).toBe(null);
+  });
+
+  it("preserves arrays (does not sort elements)", () => {
+    expect(sortKeys([3, 1, 2])).toEqual([3, 1, 2]);
+  });
+});
+
+describe("matchArgs: exact", () => {
+  it("matching objects pass", () => {
+    const r = matchArgs({ a: 1, b: 2 }, { a: 1, b: 2 }, "exact");
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("different values fail", () => {
+    const r = matchArgs({ a: 1 }, { a: 2 }, "exact");
+    expect(r.pass).toBe(false);
+    expect(r.score).toBe(0);
+    expect(r.diff.length).toBeGreaterThan(0);
+  });
+
+  it("extra keys in actual fail", () => {
+    const r = matchArgs({ a: 1, b: 2 }, { a: 1 }, "exact");
+    expect(r.pass).toBe(false);
+  });
+
+  it("missing keys in actual fail", () => {
+    const r = matchArgs({ a: 1 }, { a: 1, b: 2 }, "exact");
+    expect(r.pass).toBe(false);
+  });
+
+  it("key order doesn't matter", () => {
+    const r = matchArgs({ b: 2, a: 1 }, { a: 1, b: 2 }, "exact");
+    expect(r.pass).toBe(true);
+  });
+
+  it("handles nested objects", () => {
+    const r = matchArgs({ a: { x: 1, y: 2 } }, { a: { y: 2, x: 1 } }, "exact");
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe("matchArgs: subset (default)", () => {
+  it("expected ⊆ actual passes", () => {
+    const r = matchArgs({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, "subset");
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("extra keys in actual OK", () => {
+    const r = matchArgs({ a: 1, extra: "x" }, { a: 1 }, "subset");
+    expect(r.pass).toBe(true);
+  });
+
+  it("missing keys fail", () => {
+    const r = matchArgs({ a: 1 }, { a: 1, b: 2 }, "subset");
+    expect(r.pass).toBe(false);
+    expect(r.score).toBeLessThan(1);
+  });
+
+  it("string comparison is case-insensitive", () => {
+    const r = matchArgs({ city: "Paris" }, { city: "paris" }, "subset");
+    expect(r.pass).toBe(true);
+  });
+
+  it("string comparison trims whitespace", () => {
+    const r = matchArgs({ city: "  Paris  " }, { city: "paris" }, "subset");
+    expect(r.pass).toBe(true);
+  });
+
+  it("mismatched values fail", () => {
+    const r = matchArgs({ a: 1 }, { a: 2 }, "subset");
+    expect(r.pass).toBe(false);
+  });
+
+  it("is the default mode", () => {
+    const r = matchArgs({ a: 1, extra: 2 }, { a: 1 });
+    expect(r.pass).toBe(true);
+  });
+
+  it("partial match gives fractional score", () => {
+    const r = matchArgs({ a: 1 }, { a: 1, b: 2, c: 3 }, "subset");
+    expect(r.score).toBeCloseTo(1 / 3, 5);
+  });
+});
+
+describe("matchArgs: fuzzy", () => {
+  it("close string matches pass (Levenshtein within 20%)", () => {
+    const r = matchArgs({ city: "San Fransisco" }, { city: "San Francisco" }, "fuzzy");
+    expect(r.pass).toBe(true);
+  });
+
+  it("distant strings fail", () => {
+    const r = matchArgs({ city: "Tokyo" }, { city: "San Francisco" }, "fuzzy");
+    expect(r.pass).toBe(false);
+  });
+
+  it("number coercion: string matches number", () => {
+    const r = matchArgs({ n: "42" }, { n: 42 }, "fuzzy");
+    expect(r.pass).toBe(true);
+  });
+
+  it("numeric tolerance ±0.01", () => {
+    const r = matchArgs({ n: 3.001 }, { n: 3 }, "fuzzy");
+    expect(r.pass).toBe(true);
+  });
+
+  it("numeric tolerance violated", () => {
+    const r = matchArgs({ n: 3.5 }, { n: 3 }, "fuzzy");
+    expect(r.pass).toBe(false);
+  });
+
+  it("arrays are order-insensitive", () => {
+    const r = matchArgs({ tags: ["b", "a", "c"] }, { tags: ["a", "b", "c"] }, "fuzzy");
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe("matchArgs: setEquals", () => {
+  it("identical objects pass", () => {
+    const r = matchArgs({ a: 1, b: 2 }, { a: 1, b: 2 }, "setEquals");
+    expect(r.pass).toBe(true);
+    expect(r.score).toBe(1);
+  });
+
+  it("extra keys in actual fail", () => {
+    const r = matchArgs({ a: 1, b: 2, c: 3 }, { a: 1, b: 2 }, "setEquals");
+    expect(r.pass).toBe(false);
+  });
+
+  it("extra keys in expected fail", () => {
+    const r = matchArgs({ a: 1 }, { a: 1, b: 2 }, "setEquals");
+    expect(r.pass).toBe(false);
+  });
+
+  it("order-independent", () => {
+    const r = matchArgs({ b: 2, a: 1 }, { a: 1, b: 2 }, "setEquals");
+    expect(r.pass).toBe(true);
+  });
+});

--- a/packages/eval-harness/test/ordering.test.ts
+++ b/packages/eval-harness/test/ordering.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { gradeOrdering } from "../src/graders/ordering.js";
+import type { ObservedToolCall, EvalToolCall } from "../src/types.js";
+
+function obs(name: string, order: number): ObservedToolCall {
+  return { name, args: {}, order };
+}
+
+describe("gradeOrdering: strict", () => {
+  it("correct order passes", () => {
+    const observed = [obs("a", 0), obs("b", 1), obs("c", 2)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "strict");
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+
+  it("wrong order fails", () => {
+    const observed = [obs("c", 0), obs("b", 1), obs("a", 2)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "strict");
+    expect(s.pass).toBe(false);
+  });
+
+  it("subsequence match (extra calls between) passes", () => {
+    const observed = [obs("a", 0), obs("x", 1), obs("b", 2), obs("y", 3), obs("c", 4)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "strict");
+    expect(s.pass).toBe(true);
+  });
+
+  it("missing expected call fails", () => {
+    const observed = [obs("a", 0), obs("c", 1)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "strict");
+    expect(s.pass).toBe(false);
+  });
+});
+
+describe("gradeOrdering: unordered", () => {
+  it("all present any order passes", () => {
+    const observed = [obs("c", 0), obs("a", 1), obs("b", 2)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "unordered");
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+
+  it("missing call fails", () => {
+    const observed = [obs("a", 0), obs("c", 1)];
+    const expected: EvalToolCall[] = [
+      { name: "a", match: "subset" },
+      { name: "b", match: "subset" },
+      { name: "c", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "unordered");
+    expect(s.pass).toBe(false);
+  });
+});
+
+describe("gradeOrdering: edge cases", () => {
+  it("empty expected → passes trivially", () => {
+    const s = gradeOrdering([obs("a", 0)], [], "strict");
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+
+  it("respects explicit order field", () => {
+    const observed = [obs("a", 0), obs("b", 1)];
+    const expected: EvalToolCall[] = [
+      { name: "b", match: "subset", order: 0 },
+      { name: "a", match: "subset", order: 1 },
+    ];
+    const s = gradeOrdering(observed, expected, "strict");
+    expect(s.pass).toBe(false);
+  });
+});
+
+describe("gradeOrdering: multiset semantics", () => {
+  it("unordered: fails when expected has 2 calls to same tool but observed has only 1", () => {
+    const observed = [obs("test_weather", 0)];
+    const expected: EvalToolCall[] = [
+      { name: "test_weather", match: "subset" },
+      { name: "test_weather", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "unordered");
+    expect(s.pass).toBe(false);
+    expect(s.value).toBeCloseTo(0.5, 5);
+  });
+
+  it("unordered: passes when expected has 2 calls to same tool and observed has 2", () => {
+    const observed = [obs("test_weather", 0), obs("test_weather", 1)];
+    const expected: EvalToolCall[] = [
+      { name: "test_weather", match: "subset" },
+      { name: "test_weather", match: "subset" },
+    ];
+    const s = gradeOrdering(observed, expected, "unordered");
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+});

--- a/packages/eval-harness/test/reporters.test.ts
+++ b/packages/eval-harness/test/reporters.test.ts
@@ -1,0 +1,291 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { readFileSync, existsSync, rmSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { ConsoleReporter } from "../src/reporters/console.js";
+import { JsonlReporter } from "../src/reporters/jsonl.js";
+import type { Reporter } from "../src/reporters/types.js";
+import type { EvalTask, CaseResult, RunResult } from "../src/types.js";
+
+function makeTask(): EvalTask {
+  return {
+    schemaVersion: 1,
+    id: "task-1",
+    name: "Task One",
+    description: "desc",
+    version: "1.0.0",
+    samples: [
+      {
+        id: "s1",
+        description: "sample",
+        input: { prompt: "hi" },
+        expected: { toolSequence: "unordered" },
+        timeoutMs: 120000,
+      },
+    ],
+  };
+}
+
+function makeCaseResult(overrides: Partial<CaseResult> = {}): CaseResult {
+  return {
+    caseId: "s1",
+    pass: true,
+    scores: [{ name: "tool-selection", value: 1, pass: true, reason: "ok" }],
+    observed: {
+      toolCalls: [],
+      finalResponse: "done",
+      sessionId: "sess",
+      latencyMs: 5,
+    },
+    durationMs: 42,
+    ...overrides,
+  };
+}
+
+function makeRunResult(overrides: Partial<RunResult> = {}): RunResult {
+  const caseResult = makeCaseResult();
+  return {
+    schemaVersion: 1,
+    runId: "run-1",
+    taskId: "task-1",
+    taskVersion: "1.0.0",
+    startedAt: "2024-01-01T00:00:00.000Z",
+    finishedAt: "2024-01-01T00:00:01.000Z",
+    summary: { total: 1, passed: 1, failed: 0, errored: 0, passRate: 1 },
+    cases: [caseResult],
+    ...overrides,
+  };
+}
+
+describe("ConsoleReporter", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("implements the Reporter interface", () => {
+    const reporter: Reporter = new ConsoleReporter();
+    expect(typeof reporter.onRunStart).toBe("function");
+    expect(typeof reporter.onCaseResult).toBe("function");
+    expect(typeof reporter.onRunComplete).toBe("function");
+  });
+
+  it("onRunStart prints task name and runId", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const reporter = new ConsoleReporter();
+    reporter.onRunStart(makeTask(), "run-1");
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("Task One");
+    expect(output).toContain("1.0.0");
+    expect(output).toContain("run-1");
+  });
+
+  it("onCaseResult prints pass icon and caseId", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const reporter = new ConsoleReporter();
+    reporter.onCaseResult(makeCaseResult({ pass: true }));
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("✅");
+    expect(output).toContain("s1");
+  });
+
+  it("onCaseResult prints fail icon and failed score reasons", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const reporter = new ConsoleReporter();
+    reporter.onCaseResult(
+      makeCaseResult({
+        pass: false,
+        scores: [
+          { name: "tool-selection", value: 0, pass: false, reason: "missing tool foo" },
+        ],
+      }),
+    );
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("❌");
+    expect(output).toContain("missing tool foo");
+  });
+
+  it("onCaseResult prints warning icon and error message for infraError", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const reporter = new ConsoleReporter();
+    reporter.onCaseResult(
+      makeCaseResult({ pass: false, scores: [], infraError: "driver crashed" }),
+    );
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toContain("⚠️");
+    expect(output).toContain("driver crashed");
+  });
+
+  it("onRunComplete prints summary with counts and pass rate", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const reporter = new ConsoleReporter();
+    reporter.onRunComplete(makeRunResult());
+    const output = spy.mock.calls.map((c) => c.join(" ")).join("\n");
+    expect(output).toMatch(/1\s*\/\s*1/);
+    expect(output).toContain("100");
+  });
+});
+
+describe("JsonlReporter", () => {
+  const created: string[] = [];
+
+  afterEach(() => {
+    for (const p of created.splice(0)) {
+      try {
+        rmSync(p, { recursive: true, force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+  });
+
+  function tempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "eval-jsonl-"));
+    created.push(dir);
+    return dir;
+  }
+
+  it("implements the Reporter interface", () => {
+    const reporter: Reporter = new JsonlReporter(tempDir());
+    expect(typeof reporter.onRunStart).toBe("function");
+    expect(typeof reporter.onCaseResult).toBe("function");
+    expect(typeof reporter.onRunComplete).toBe("function");
+  });
+
+  it("writes a JSONL file containing run, sample, and summary lines", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    const task = makeTask();
+    const runResult = makeRunResult();
+    reporter.onRunStart(task, runResult.runId);
+    reporter.onCaseResult(runResult.cases[0]);
+    reporter.onRunComplete(runResult);
+
+    const filePath = join(dir, `${runResult.runId}.jsonl`);
+    expect(existsSync(filePath)).toBe(true);
+    const lines = readFileSync(filePath, "utf8").trim().split("\n");
+    expect(lines.length).toBeGreaterThanOrEqual(3);
+    const parsed = lines.map((l) => JSON.parse(l));
+    const types = parsed.map((p) => p.type);
+    expect(types).toContain("run");
+    expect(types).toContain("sample");
+    expect(types).toContain("summary");
+  });
+
+  it("creates the output directory if it does not exist", () => {
+    const base = tempDir();
+    const nested = join(base, "nested", "deeper");
+    const reporter = new JsonlReporter(nested);
+    const task = makeTask();
+    const runResult = makeRunResult();
+    reporter.onRunStart(task, runResult.runId);
+    reporter.onCaseResult(runResult.cases[0]);
+    reporter.onRunComplete(runResult);
+    expect(existsSync(nested)).toBe(true);
+    expect(existsSync(join(nested, `${runResult.runId}.jsonl`))).toBe(true);
+  });
+
+  it("writes failure artifact JSON for each failed case", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    const failed = makeCaseResult({
+      caseId: "bad-case",
+      pass: false,
+      scores: [{ name: "tool-selection", value: 0, pass: false, reason: "nope" }],
+    });
+    const runResult = makeRunResult({
+      summary: { total: 1, passed: 0, failed: 1, errored: 0, passRate: 0 },
+      cases: [failed],
+    });
+    reporter.onRunStart(makeTask(), runResult.runId);
+    reporter.onCaseResult(failed);
+    reporter.onRunComplete(runResult);
+
+    const artifactPath = join(dir, runResult.runId, "bad-case.json");
+    expect(existsSync(artifactPath)).toBe(true);
+    const parsed = JSON.parse(readFileSync(artifactPath, "utf8"));
+    expect(parsed.caseId).toBe("bad-case");
+    expect(parsed.pass).toBe(false);
+  });
+
+  it("writes header line on onRunStart (before onRunComplete) — survives crash", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    const task = makeTask();
+    reporter.onRunStart(task, "run-streaming");
+    const filePath = join(dir, "run-streaming.jsonl");
+    expect(existsSync(filePath)).toBe(true);
+    const lines = readFileSync(filePath, "utf8").trim().split("\n").filter(Boolean);
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const parsed = JSON.parse(lines[0]);
+    expect(parsed.type).toBe("run");
+    expect(parsed.runId).toBe("run-streaming");
+  });
+
+  it("writes case line on each onCaseResult (file grows incrementally)", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    const task = makeTask();
+    reporter.onRunStart(task, "run-grow");
+    const filePath = join(dir, "run-grow.jsonl");
+    const sizeAfterStart = readFileSync(filePath, "utf8").length;
+
+    reporter.onCaseResult(makeCaseResult({ caseId: "c1" }));
+    const sizeAfter1 = readFileSync(filePath, "utf8").length;
+    expect(sizeAfter1).toBeGreaterThan(sizeAfterStart);
+
+    reporter.onCaseResult(makeCaseResult({ caseId: "c2" }));
+    const sizeAfter2 = readFileSync(filePath, "utf8").length;
+    expect(sizeAfter2).toBeGreaterThan(sizeAfter1);
+
+    const lines = readFileSync(filePath, "utf8").trim().split("\n").filter(Boolean);
+    const parsed = lines.map((l) => JSON.parse(l));
+    expect(parsed.filter((p) => p.type === "sample")).toHaveLength(2);
+  });
+
+  it("writes failure artifact immediately on failed onCaseResult (before onRunComplete)", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    reporter.onRunStart(makeTask(), "run-fail-immediate");
+    const failed = makeCaseResult({
+      caseId: "early-fail",
+      pass: false,
+      scores: [{ name: "x", value: 0, pass: false, reason: "boom" }],
+    });
+    reporter.onCaseResult(failed);
+    const artifactPath = join(dir, "run-fail-immediate", "early-fail.json");
+    expect(existsSync(artifactPath)).toBe(true);
+  });
+
+  it("sanitizes unsafe caseId in artifact path (no traversal)", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    reporter.onRunStart(makeTask(), "run-traversal");
+    const failed = makeCaseResult({
+      caseId: "../../escape/evil",
+      pass: false,
+      scores: [{ name: "x", value: 0, pass: false, reason: "boom" }],
+    });
+    reporter.onCaseResult(failed);
+    // Must NOT have written outside the run artifact dir.
+    const escaped = join(dir, "..", "escape", "evil.json");
+    expect(existsSync(escaped)).toBe(false);
+    // The artifact must be present *inside* the run artifact dir under a sanitized name.
+    const artifactDir = join(dir, "run-traversal");
+    expect(existsSync(artifactDir)).toBe(true);
+    const entries = require("node:fs").readdirSync(artifactDir);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).not.toContain("/");
+    expect(entries[0]).not.toContain("..");
+  });
+
+  it("sanitizes unsafe runId in jsonl filename (no traversal)", () => {
+    const dir = tempDir();
+    const reporter = new JsonlReporter(dir);
+    // Pass a runId that would escape if used raw.
+    reporter.onRunStart(makeTask(), "../../evil-run");
+    // The reporter should not have created any file outside `dir`.
+    const escapedDirParent = join(dir, "..");
+    const before = require("node:fs").readdirSync(escapedDirParent);
+    expect(before.some((e: string) => e === "evil-run.jsonl")).toBe(false);
+  });
+});

--- a/packages/eval-harness/test/response.test.ts
+++ b/packages/eval-harness/test/response.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { gradeResponse } from "../src/graders/response.js";
+
+describe("gradeResponse", () => {
+  it("containsAny: one match → pass", () => {
+    const s = gradeResponse("The answer is 42", { containsAny: ["42", "100"] });
+    expect(s).toBeDefined();
+    expect(s!.pass).toBe(true);
+  });
+
+  it("containsAny: no match → fail", () => {
+    const s = gradeResponse("Something else", { containsAny: ["42", "100"] });
+    expect(s!.pass).toBe(false);
+  });
+
+  it("containsAll: all present → pass", () => {
+    const s = gradeResponse("alpha and beta and gamma", { containsAll: ["alpha", "beta", "gamma"] });
+    expect(s!.pass).toBe(true);
+    expect(s!.value).toBe(1);
+  });
+
+  it("containsAll: one missing → fail", () => {
+    const s = gradeResponse("alpha and beta", { containsAll: ["alpha", "beta", "gamma"] });
+    expect(s!.pass).toBe(false);
+    expect(s!.value).toBeLessThan(1);
+  });
+
+  it("case-insensitive matching", () => {
+    const s = gradeResponse("The ANSWER is here", { containsAll: ["answer"] });
+    expect(s!.pass).toBe(true);
+  });
+
+  it("undefined response config → returns undefined (skip)", () => {
+    const s = gradeResponse("anything", undefined);
+    expect(s).toBeUndefined();
+  });
+
+  it("uses word-boundary matching: 'hi' does NOT match 'this is helpful'", () => {
+    const s = gradeResponse("this is helpful", { containsAny: ["hi"] });
+    expect(s).toBeDefined();
+    expect(s!.pass).toBe(false);
+  });
+
+  it("word-boundary: 'hi' DOES match 'hi there'", () => {
+    const s = gradeResponse("hi there", { containsAny: ["hi"] });
+    expect(s!.pass).toBe(true);
+  });
+
+  it("word-boundary: 'hello' matches inside punctuation 'hello,'", () => {
+    const s = gradeResponse("hello, world", { containsAny: ["hello"] });
+    expect(s!.pass).toBe(true);
+  });
+
+  it("word-boundary: 'cat' does NOT match 'concatenation'", () => {
+    const s = gradeResponse("look at this concatenation", { containsAny: ["cat"] });
+    expect(s!.pass).toBe(false);
+  });
+
+  it("word-boundary: containsAll respects boundaries too", () => {
+    const s = gradeResponse("this is helpful", { containsAll: ["hi"] });
+    expect(s!.pass).toBe(false);
+  });
+});

--- a/packages/eval-harness/test/runner.test.ts
+++ b/packages/eval-harness/test/runner.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, vi } from "vitest";
+import { EvalRunner } from "../src/runner.js";
+import type { Reporter } from "../src/reporters/types.js";
+import { FakeDriver } from "../src/drivers/fake-driver.js";
+import type { Driver } from "../src/drivers/types.js";
+import type { EvalSample, EvalTask, ObservedResult } from "../src/types.js";
+
+function sample(id: string, toolName = "add"): EvalSample {
+  return {
+    id,
+    description: `sample ${id}`,
+    input: { prompt: `run ${id}` },
+    expected: {
+      toolCalls: [{ name: toolName, args: { a: 1, b: 2 }, match: "subset" }],
+      toolSequence: "unordered",
+    },
+    timeoutMs: 120000,
+  };
+}
+
+function task(samples: EvalSample[]): EvalTask {
+  return {
+    schemaVersion: 1,
+    id: "task-x",
+    name: "Task X",
+    description: "a task",
+    version: "1.0.0",
+    samples,
+  };
+}
+
+function observed(overrides: Partial<ObservedResult> = {}): ObservedResult {
+  return {
+    toolCalls: [{ name: "add", args: { a: 1, b: 2 }, order: 0 }],
+    finalResponse: "done",
+    sessionId: "sess-1",
+    latencyMs: 10,
+    ...overrides,
+  };
+}
+
+describe("EvalRunner.runTask", () => {
+  it("runs a single-case task and returns a RunResult", async () => {
+    const driver = FakeDriver.fromMap({
+      "s1": observed(),
+    });
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.schemaVersion).toBe(1);
+    expect(result.cases).toHaveLength(1);
+    expect(result.summary.total).toBe(1);
+  });
+
+  it("includes correct runId, taskId, and taskVersion", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, runId: "run-abc" });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.runId).toBe("run-abc");
+    expect(result.taskId).toBe("task-x");
+    expect(result.taskVersion).toBe("1.0.0");
+  });
+
+  it("passing case has pass=true and all scores pass", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases[0].pass).toBe(true);
+    expect(result.cases[0].scores.length).toBeGreaterThan(0);
+    expect(result.cases[0].scores.every((s) => s.pass)).toBe(true);
+  });
+
+  it("failing case has pass=false with failing scores present", async () => {
+    const driver = FakeDriver.fromMap({
+      "s1": observed({ toolCalls: [{ name: "wrong_tool", args: {}, order: 0 }] }),
+    });
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases[0].pass).toBe(false);
+    expect(result.cases[0].scores.some((s) => !s.pass)).toBe(true);
+  });
+
+  it("multiple cases: summary totals correct (passed, failed, errored)", async () => {
+    const throwingDriver: Driver = {
+      async run(s) {
+        if (s.id === "s3") throw new Error("boom");
+        if (s.id === "s1") return observed();
+        return observed({ toolCalls: [{ name: "wrong_tool", args: {}, order: 0 }] });
+      },
+    };
+    const runner = new EvalRunner({ driver: throwingDriver });
+    const result = await runner.runTask(task([sample("s1"), sample("s2"), sample("s3")]));
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.passed).toBe(1);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.errored).toBe(1);
+  });
+
+  it("calculates passRate correctly", async () => {
+    const driver: Driver = {
+      async run(s) {
+        if (s.id === "s1") return observed();
+        return observed({ toolCalls: [{ name: "wrong", args: {}, order: 0 }] });
+      },
+    };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1"), sample("s2")]));
+    expect(result.summary.passRate).toBe(0.5);
+  });
+
+  it("captures infraError when driver throws", async () => {
+    const driver: Driver = {
+      async run() {
+        throw new Error("driver exploded");
+      },
+    };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases[0].infraError).toContain("driver exploded");
+  });
+
+  it("infraError case: pass=false and scores empty", async () => {
+    const driver: Driver = {
+      async run() {
+        throw new Error("fail");
+      },
+    };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases[0].pass).toBe(false);
+    expect(result.cases[0].scores).toEqual([]);
+  });
+
+  it("calls reporters.onRunStart with task and runId", async () => {
+    const reporter: Reporter = {
+      onRunStart: vi.fn(),
+      onCaseResult: vi.fn(),
+      onRunComplete: vi.fn(),
+    };
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, reporters: [reporter], runId: "r1" });
+    const t = task([sample("s1")]);
+    await runner.runTask(t);
+    expect(reporter.onRunStart).toHaveBeenCalledWith(t, "r1");
+  });
+
+  it("calls reporters.onCaseResult for each case", async () => {
+    const reporter: Reporter = {
+      onRunStart: vi.fn(),
+      onCaseResult: vi.fn(),
+      onRunComplete: vi.fn(),
+    };
+    const driver = FakeDriver.fromMap({ "s1": observed(), "s2": observed() });
+    const runner = new EvalRunner({ driver, reporters: [reporter] });
+    await runner.runTask(task([sample("s1"), sample("s2")]));
+    expect(reporter.onCaseResult).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls reporters.onRunComplete with full RunResult", async () => {
+    const reporter: Reporter = {
+      onRunStart: vi.fn(),
+      onCaseResult: vi.fn(),
+      onRunComplete: vi.fn(),
+    };
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, reporters: [reporter] });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(reporter.onRunComplete).toHaveBeenCalledWith(result);
+  });
+});
+
+describe("EvalRunner.checkPassRateFloor", () => {
+  it("returns true when passRate >= floor, false when below", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    // one passing case → passRate = 1.0
+    expect(runner.checkPassRateFloor(result, 0.5)).toBe(true);
+    expect(runner.checkPassRateFloor(result, 1.0)).toBe(true);
+    // unreachable floor
+    const badDriver = FakeDriver.fromMap({
+      "s1": observed({ toolCalls: [{ name: "wrong", args: {}, order: 0 }] }),
+    });
+    const runner2 = new EvalRunner({ driver: badDriver });
+    const result2 = await runner2.runTask(task([sample("s1")]));
+    expect(runner2.checkPassRateFloor(result2, 0.5)).toBe(false);
+  });
+});
+
+describe("EvalRunner: timeoutMs enforcement", () => {
+  it("passes timeoutMs to driver via DriverOptions", async () => {
+    const captured: Array<number | undefined> = [];
+    const driver: Driver = {
+      async run(_s, options) {
+        captured.push(options?.timeout);
+        return observed();
+      },
+    };
+    const s: EvalSample = { ...sample("s1"), timeoutMs: 4242 };
+    const runner = new EvalRunner({ driver });
+    await runner.runTask(task([s]));
+    expect(captured).toEqual([4242]);
+  });
+
+  it("marks case as infraError when driver exceeds timeout", async () => {
+    const driver: Driver = {
+      run() {
+        return new Promise(() => {
+          /* never resolves */
+        });
+      },
+    };
+    const s: EvalSample = { ...sample("s1"), timeoutMs: 50 };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([s]));
+    expect(result.cases[0].infraError).toBeDefined();
+    expect(result.cases[0].infraError).toMatch(/timeout/i);
+    expect(result.cases[0].pass).toBe(false);
+  });
+});
+
+describe("EvalRunner: zero-expectation samples", () => {
+  it("sample with no expectations passes", async () => {
+    const noExpectSample: EvalSample = {
+      id: "noexp",
+      description: "no expectations",
+      input: { prompt: "anything" },
+      expected: { toolSequence: "unordered" },
+      timeoutMs: 120000,
+    };
+    const driver = FakeDriver.fromMap({
+      "noexp": observed({ toolCalls: [], finalResponse: "anything goes" }),
+    });
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([noExpectSample]));
+    expect(result.cases[0].pass).toBe(true);
+    expect(result.cases[0].scores).toEqual([]);
+  });
+});
+
+describe("EvalRunner: AbortSignal on timeout", () => {
+  it("aborts driver via signal when sample timeoutMs elapses", async () => {
+    let receivedSignal: AbortSignal | undefined;
+    const driver: Driver = {
+      run(_sample, options) {
+        receivedSignal = options?.signal;
+        return new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(new Error("driver observed abort"));
+          });
+        });
+      },
+    };
+    const s: EvalSample = { ...sample("s1"), timeoutMs: 30 };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([s]));
+    expect(receivedSignal).toBeDefined();
+    expect(receivedSignal!.aborted).toBe(true);
+    expect(result.cases[0].infraError).toBeDefined();
+  });
+
+  it("does NOT abort signal when driver finishes normally", async () => {
+    let signalAfter: boolean | undefined;
+    const driver: Driver = {
+      async run(_sample, options) {
+        const result = observed();
+        signalAfter = options?.signal?.aborted;
+        return result;
+      },
+    };
+    const runner = new EvalRunner({ driver });
+    await runner.runTask(task([sample("s1")]));
+    expect(signalAfter).toBe(false);
+  });
+});
+
+describe("EvalRunner: runId per runTask", () => {
+  it("generates a fresh runId per runTask call when none is supplied", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver });
+    const r1 = await runner.runTask(task([sample("s1")]));
+    const r2 = await runner.runTask(task([sample("s1")]));
+    expect(r1.runId).toBeTruthy();
+    expect(r2.runId).toBeTruthy();
+    expect(r1.runId).not.toBe(r2.runId);
+  });
+
+  it("reuses a constructor-supplied runId across runTask calls", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, runId: "fixed-id" });
+    const r1 = await runner.runTask(task([sample("s1")]));
+    const r2 = await runner.runTask(task([sample("s1")]));
+    expect(r1.runId).toBe("fixed-id");
+    expect(r2.runId).toBe("fixed-id");
+  });
+
+  it("sanitizes a constructor-supplied runId so it is path-safe", async () => {
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, runId: "../../evil/run id" });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.runId).not.toContain("/");
+    expect(result.runId).not.toContain("..");
+    expect(result.runId).not.toContain(" ");
+  });
+});
+
+describe("EvalRunner: grader and reporter resilience", () => {
+  it("does not abort run when a reporter throws — logs and continues", async () => {
+    const flakyReporter: Reporter = {
+      onRunStart: vi.fn(() => {
+        throw new Error("reporter onRunStart boom");
+      }),
+      onCaseResult: vi.fn(() => {
+        throw new Error("reporter onCaseResult boom");
+      }),
+      onRunComplete: vi.fn(() => {
+        throw new Error("reporter onRunComplete boom");
+      }),
+    };
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, reporters: [flakyReporter] });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases).toHaveLength(1);
+    expect(result.cases[0].pass).toBe(true);
+    warn.mockRestore();
+  });
+
+  it("captures error stack in infraError when driver throws", async () => {
+    const driver: Driver = {
+      async run() {
+        throw new Error("driver kaboom");
+      },
+    };
+    const runner = new EvalRunner({ driver });
+    const result = await runner.runTask(task([sample("s1")]));
+    expect(result.cases[0].infraError).toContain("driver kaboom");
+    expect(result.cases[0].infraError).toMatch(/at /);
+  });
+
+  it("awaits async reporter methods", async () => {
+    const order: string[] = [];
+    const asyncReporter: Reporter = {
+      async onRunStart() {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push("start");
+      },
+      async onCaseResult() {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push("case");
+      },
+      async onRunComplete() {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push("complete");
+      },
+    };
+    const driver = FakeDriver.fromMap({ "s1": observed() });
+    const runner = new EvalRunner({ driver, reporters: [asyncReporter] });
+    await runner.runTask(task([sample("s1")]));
+    expect(order).toEqual(["start", "case", "complete"]);
+  });
+});

--- a/packages/eval-harness/test/tool-selection.test.ts
+++ b/packages/eval-harness/test/tool-selection.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect } from "vitest";
+import { gradeToolSelection } from "../src/graders/tool-selection.js";
+import type { ObservedToolCall, EvalExpected } from "../src/types.js";
+
+function call(name: string, args: Record<string, unknown> = {}, order = 0): ObservedToolCall {
+  return { name, args, order };
+}
+
+describe("gradeToolSelection: tool-names", () => {
+  it("correct tool called → pass", () => {
+    const observed = [call("add", { a: 1, b: 2 })];
+    const exp: EvalExpected = { toolCalls: [{ name: "add", match: "subset" }], toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, exp);
+    const s = scores.find((x) => x.name === "tool-names");
+    expect(s).toBeDefined();
+    expect(s!.pass).toBe(true);
+    expect(s!.value).toBe(1);
+  });
+
+  it("wrong tool called → fail", () => {
+    const observed = [call("multiply")];
+    const expected: EvalExpected = { toolCalls: [{ name: "add", match: "subset" }], toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "tool-names");
+    expect(s!.pass).toBe(false);
+    expect(s!.value).toBe(0);
+  });
+
+  it("multiple expected tools, all present → pass", () => {
+    const observed = [call("add"), call("multiply")];
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "add", match: "subset" },
+        { name: "multiply", match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "tool-names")!;
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+
+  it("multiple expected tools, one missing → partial score", () => {
+    const observed = [call("add")];
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "add", match: "subset" },
+        { name: "multiply", match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "tool-names")!;
+    expect(s.pass).toBe(false);
+    expect(s.value).toBeCloseTo(0.5, 5);
+  });
+});
+
+describe("gradeToolSelection: forbidden-tools", () => {
+  it("forbidden tool called → fail", () => {
+    const observed = [call("delete_all")];
+    const expected: EvalExpected = { forbiddenTools: ["delete_all"], toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "forbidden-tools")!;
+    expect(s.pass).toBe(false);
+  });
+
+  it("forbidden tool not called → pass", () => {
+    const observed = [call("add")];
+    const expected: EvalExpected = { forbiddenTools: ["delete_all"], toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "forbidden-tools")!;
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+});
+
+describe("gradeToolSelection: no-tool-compliance", () => {
+  it("noToolCall=true with no calls → pass", () => {
+    const observed: ObservedToolCall[] = [];
+    const expected: EvalExpected = { noToolCall: true, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "no-tool-compliance")!;
+    expect(s.pass).toBe(true);
+  });
+
+  it("noToolCall=true with calls → fail", () => {
+    const observed = [call("add")];
+    const expected: EvalExpected = { noToolCall: true, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "no-tool-compliance")!;
+    expect(s.pass).toBe(false);
+  });
+});
+
+describe("gradeToolSelection: call-count", () => {
+  it("minCalls met → pass", () => {
+    const observed = [call("add"), call("add")];
+    const expected: EvalExpected = { minCalls: 2, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "call-count")!;
+    expect(s.pass).toBe(true);
+  });
+
+  it("minCalls not met → fail", () => {
+    const observed = [call("add")];
+    const expected: EvalExpected = { minCalls: 2, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "call-count")!;
+    expect(s.pass).toBe(false);
+  });
+
+  it("maxCalls exceeded → fail", () => {
+    const observed = [call("add"), call("add"), call("add")];
+    const expected: EvalExpected = { maxCalls: 2, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "call-count")!;
+    expect(s.pass).toBe(false);
+  });
+
+  it("within min/max range → pass", () => {
+    const observed = [call("add"), call("add")];
+    const expected: EvalExpected = { minCalls: 1, maxCalls: 3, toolSequence: "unordered" };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "call-count")!;
+    expect(s.pass).toBe(true);
+  });
+});
+
+describe("gradeToolSelection: multiset semantics", () => {
+  it("fails when expected has 2 calls to same tool but observed has only 1", () => {
+    const observed = [call("test_weather", { city: "Paris" })];
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "test_weather", match: "subset" },
+        { name: "test_weather", match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "tool-names")!;
+    expect(s.pass).toBe(false);
+    expect(s.value).toBeCloseTo(0.5, 5);
+  });
+
+  it("passes when expected has 2 calls to same tool and observed has 2", () => {
+    const observed = [call("test_weather", { city: "Paris" }), call("test_weather", { city: "London" })];
+    const expected: EvalExpected = {
+      toolCalls: [
+        { name: "test_weather", match: "subset" },
+        { name: "test_weather", match: "subset" },
+      ],
+      toolSequence: "unordered",
+    };
+    const scores = gradeToolSelection(observed, expected);
+    const s = scores.find((x) => x.name === "tool-names")!;
+    expect(s.pass).toBe(true);
+    expect(s.value).toBe(1);
+  });
+});

--- a/packages/eval-harness/test/tool-tracker-observer.test.ts
+++ b/packages/eval-harness/test/tool-tracker-observer.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { extractObservedCalls } from "../src/observers/tool-tracker.js";
+import { ObservedToolCallSchema } from "../src/types.js";
+import type { EvalToolTracker } from "../src/fixtures/eval-tools.js";
+
+function makeTracker(invocations: EvalToolTracker["invocations"]): EvalToolTracker {
+  return {
+    invocations,
+    reset() {
+      this.invocations = [];
+    },
+  };
+}
+
+describe("extractObservedCalls", () => {
+  it("extracts ObservedToolCall[] from tracker invocations", () => {
+    const tracker = makeTracker([
+      {
+        name: "test_add",
+        args: { a: 1, b: 2 },
+        result: { result: 3 },
+        timestamp: 1000,
+        order: 0,
+      },
+    ]);
+    const observed = extractObservedCalls(tracker);
+    expect(observed).toHaveLength(1);
+    expect(observed[0].name).toBe("test_add");
+    expect(observed[0].args).toEqual({ a: 1, b: 2 });
+    expect(observed[0].result).toEqual({ result: 3 });
+  });
+
+  it("preserves order field", () => {
+    const tracker = makeTracker([
+      { name: "a", args: {}, result: null, timestamp: 1, order: 0 },
+      { name: "b", args: {}, result: null, timestamp: 2, order: 1 },
+      { name: "c", args: {}, result: null, timestamp: 3, order: 2 },
+    ]);
+    const observed = extractObservedCalls(tracker);
+    expect(observed.map((o) => o.order)).toEqual([0, 1, 2]);
+  });
+
+  it("preserves args and result", () => {
+    const tracker = makeTracker([
+      {
+        name: "test_weather",
+        args: { city: "Paris", unit: "celsius" },
+        result: { temperature: 22, city: "Paris" },
+        timestamp: 5,
+        order: 0,
+      },
+    ]);
+    const observed = extractObservedCalls(tracker);
+    expect(observed[0].args).toEqual({ city: "Paris", unit: "celsius" });
+    expect(observed[0].result).toEqual({ temperature: 22, city: "Paris" });
+    expect(observed[0].timestamp).toBe(5);
+  });
+
+  it("returns empty array for empty tracker", () => {
+    const tracker = makeTracker([]);
+    expect(extractObservedCalls(tracker)).toEqual([]);
+  });
+
+  it("produces output that validates against ObservedToolCallSchema", () => {
+    const tracker = makeTracker([
+      {
+        name: "test_multiply",
+        args: { a: 3, b: 4 },
+        result: { result: 12 },
+        timestamp: 100,
+        order: 0,
+      },
+    ]);
+    const observed = extractObservedCalls(tracker);
+    for (const call of observed) {
+      expect(() => ObservedToolCallSchema.parse(call)).not.toThrow();
+    }
+  });
+});

--- a/packages/eval-harness/test/types.test.ts
+++ b/packages/eval-harness/test/types.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "vitest";
+import {
+  EvalTaskSchema,
+  EvalSampleSchema,
+  EvalToolCallSchema,
+  EvalExpectedSchema,
+  RunResultSchema,
+  CaseResultSchema,
+  ScoreSchema,
+  ObservedResultSchema,
+  ObservedToolCallSchema,
+} from "../src/types.js";
+
+const validTask = {
+  schemaVersion: 1,
+  id: "task.basic",
+  name: "Basic Task",
+  description: "A basic eval task",
+  version: "1.0.0",
+  samples: [
+    {
+      id: "single.add.basic",
+      description: "Add two numbers",
+      input: { prompt: "What is 2+2?" },
+      expected: {
+        toolCalls: [{ name: "test_add", args: { a: 2, b: 2 } }],
+      },
+    },
+  ],
+};
+
+describe("EvalTaskSchema", () => {
+  it("accepts a valid EvalTask JSON", () => {
+    const result = EvalTaskSchema.safeParse(validTask);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required field: id", () => {
+    const { id, ...noId } = validTask;
+    const result = EvalTaskSchema.safeParse(noId);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field: name", () => {
+    const { name, ...noName } = validTask;
+    const result = EvalTaskSchema.safeParse(noName);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects missing required field: samples", () => {
+    const { samples, ...noSamples } = validTask;
+    const result = EvalTaskSchema.safeParse(noSamples);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects invalid schemaVersion (!= 1)", () => {
+    const bad = { ...validTask, schemaVersion: 2 };
+    const result = EvalTaskSchema.safeParse(bad);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-semver version string? (accepts any string version)", () => {
+    const ok = { ...validTask, version: "1.0.0" };
+    expect(EvalTaskSchema.safeParse(ok).success).toBe(true);
+  });
+
+  it("applies default passRateFloor is optional (no default coerced)", () => {
+    const parsed = EvalTaskSchema.parse(validTask);
+    // passRateFloor is optional; not required but may default
+    expect(parsed.schemaVersion).toBe(1);
+  });
+});
+
+describe("EvalToolCallSchema", () => {
+  it("defaults match to 'subset' when omitted", () => {
+    const parsed = EvalToolCallSchema.parse({ name: "test_add" });
+    expect(parsed.match).toBe("subset");
+  });
+
+  it("accepts all valid match modes", () => {
+    for (const m of ["exact", "subset", "fuzzy", "setEquals"]) {
+      const r = EvalToolCallSchema.safeParse({ name: "x", match: m });
+      expect(r.success).toBe(true);
+    }
+  });
+
+  it("rejects invalid match mode", () => {
+    const r = EvalToolCallSchema.safeParse({ name: "x", match: "bogus" });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects missing tool name", () => {
+    const r = EvalToolCallSchema.safeParse({ args: {} });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("EvalExpectedSchema", () => {
+  it("defaults toolSequence to 'unordered'", () => {
+    const parsed = EvalExpectedSchema.parse({});
+    expect(parsed.toolSequence).toBe("unordered");
+  });
+
+  it("accepts 'strict' and 'unordered' toolSequence", () => {
+    expect(EvalExpectedSchema.safeParse({ toolSequence: "strict" }).success).toBe(true);
+    expect(EvalExpectedSchema.safeParse({ toolSequence: "unordered" }).success).toBe(true);
+  });
+
+  it("rejects invalid toolSequence", () => {
+    const r = EvalExpectedSchema.safeParse({ toolSequence: "random" });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts forbiddenTools, minCalls, maxCalls, noToolCall", () => {
+    const r = EvalExpectedSchema.safeParse({
+      forbiddenTools: ["a", "b"],
+      minCalls: 1,
+      maxCalls: 3,
+      noToolCall: true,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts response.containsAny/containsAll", () => {
+    const r = EvalExpectedSchema.safeParse({
+      response: { containsAny: ["x"], containsAll: ["y"] },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("accepts cms.stateIn", () => {
+    const r = EvalExpectedSchema.safeParse({ cms: { stateIn: ["Ready", "Idle"] } });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects noToolCall=true combined with toolCalls entries", () => {
+    const r = EvalExpectedSchema.safeParse({
+      noToolCall: true,
+      toolCalls: [{ name: "test_add" }],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts noToolCall=true when toolCalls is omitted or empty", () => {
+    expect(EvalExpectedSchema.safeParse({ noToolCall: true }).success).toBe(true);
+    expect(EvalExpectedSchema.safeParse({ noToolCall: true, toolCalls: [] }).success).toBe(true);
+  });
+
+  it("rejects minCalls > maxCalls", () => {
+    const r = EvalExpectedSchema.safeParse({ minCalls: 5, maxCalls: 2 });
+    expect(r.success).toBe(false);
+  });
+
+  it("accepts minCalls === maxCalls", () => {
+    const r = EvalExpectedSchema.safeParse({ minCalls: 3, maxCalls: 3 });
+    expect(r.success).toBe(true);
+  });
+});
+
+describe("EvalSampleSchema", () => {
+  it("applies default timeoutMs (120000)", () => {
+    const parsed = EvalSampleSchema.parse({
+      id: "s1",
+      description: "d",
+      input: { prompt: "p" },
+      expected: {},
+    });
+    expect(parsed.timeoutMs).toBe(120000);
+  });
+
+  it("accepts context with role user/assistant", () => {
+    const r = EvalSampleSchema.safeParse({
+      id: "s1",
+      description: "d",
+      input: {
+        prompt: "p",
+        context: [
+          { role: "user", content: "hi" },
+          { role: "assistant", content: "hello" },
+        ],
+      },
+      expected: {},
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects invalid role in context", () => {
+    const r = EvalSampleSchema.safeParse({
+      id: "s1",
+      description: "d",
+      input: {
+        prompt: "p",
+        context: [{ role: "system", content: "x" }],
+      },
+      expected: {},
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe("ScoreSchema / ObservedResultSchema / CaseResultSchema / RunResultSchema", () => {
+  it("validates a Score", () => {
+    const r = ScoreSchema.safeParse({
+      name: "tool_match",
+      value: 1,
+      pass: true,
+      reason: "matched",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("validates an ObservedToolCall with order", () => {
+    const r = ObservedToolCallSchema.safeParse({
+      name: "t",
+      args: { a: 1 },
+      order: 0,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("validates an ObservedResult", () => {
+    const r = ObservedResultSchema.safeParse({
+      toolCalls: [],
+      finalResponse: "hi",
+      sessionId: "s1",
+      latencyMs: 42,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("validates a CaseResult", () => {
+    const r = CaseResultSchema.safeParse({
+      caseId: "c1",
+      pass: true,
+      scores: [],
+      observed: {
+        toolCalls: [],
+        finalResponse: "",
+        sessionId: "s1",
+        latencyMs: 1,
+      },
+      durationMs: 1,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("validates a full RunResult", () => {
+    const r = RunResultSchema.safeParse({
+      schemaVersion: 1,
+      runId: "r1",
+      taskId: "t1",
+      taskVersion: "1.0.0",
+      startedAt: "2025-01-01T00:00:00Z",
+      finishedAt: "2025-01-01T00:00:01Z",
+      summary: { total: 1, passed: 1, failed: 0, errored: 0, passRate: 1 },
+      cases: [
+        {
+          caseId: "c1",
+          pass: true,
+          scores: [],
+          observed: {
+            toolCalls: [],
+            finalResponse: "",
+            sessionId: "s1",
+            latencyMs: 1,
+          },
+          durationMs: 1,
+        },
+      ],
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects RunResult with invalid schemaVersion", () => {
+    const r = RunResultSchema.safeParse({
+      schemaVersion: 99,
+      runId: "r1",
+      taskId: "t1",
+      taskVersion: "1.0.0",
+      startedAt: "x",
+      finishedAt: "y",
+      summary: { total: 0, passed: 0, failed: 0, errored: 0, passRate: 0 },
+      cases: [],
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/packages/eval-harness/tsconfig.json
+++ b/packages/eval-harness/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "test"]
+}

--- a/packages/eval-harness/vitest.config.ts
+++ b/packages/eval-harness/vitest.config.ts
@@ -1,0 +1,26 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const testModelProvidersPath = path.join(
+  __dirname,
+  "../sdk/test/fixtures/model-providers.test.json",
+);
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.test.ts"],
+    pool: "forks",
+    // Eval samples default to 120s (sample.timeoutMs). Vitest must give the
+    // runner room to enforce its own per-sample timeout *plus* setup/teardown
+    // before killing the test. 180s = 120s sample default + 60s headroom.
+    testTimeout: 180_000,
+    hookTimeout: 60_000,
+    env: {
+      RUST_LOG: "error",
+      PS_MODEL_PROVIDERS_PATH:
+        process.env.PS_MODEL_PROVIDERS_PATH || testModelProvidersPath,
+    },
+  },
+});


### PR DESCRIPTION
This PR adds the packages/eval-harness package on top of the latest upstream main.

It includes:

the eval harness package structure
dataset, drivers, graders, and reporters
tests and package configuration