### PR TITLE
Refactor resource naming and expose csiIdentityClientId in Portal/Worker

### DIFF
--- a/deploy/envs/template.env
+++ b/deploy/envs/template.env
@@ -46,7 +46,7 @@ PORTAL_RESOURCE_NAME=
 NAMESPACE=pilotswarm
 
 # ─── Bicep input parameters (static) ───
-# SSL_CERT_DOMAIN_SUFFIX is only consumed by the EV2 / enterprise path
+# SSL_CERT_DOMAIN_SUFFIX is only consumed by the enterprise path
 # (cert subject = `${resourceName}.${SSL_CERT_DOMAIN_SUFFIX}`); OSS deploys
 # leave it empty and bicep derives the cert subject from the AppGw's Azure
 # DNS label instead.
@@ -86,7 +86,7 @@ WAF_CUSTOM_RULES_FILE=
 #             for Private Link`). For OSS, the cert subject is the AppGw's
 #             `<name>.<region>.cloudapp.azure.com` Azure DNS label and LE
 #             issues via cert-manager (TLS_SOURCE=letsencrypt) — zero DNS
-#             prerequisite. For EV2 / enterprise the subject is
+#             prerequisite. For enterprise the subject is
 #             `${resourceName}.${SSL_CERT_DOMAIN_SUFFIX}` and the cert
 #             comes from an AKV-registered issuer (TLS_SOURCE=akv).
 #   private — AppGw private-IP listener only, no AFD. Caller manages DNS
@@ -101,7 +101,7 @@ EDGE_MODE=afd
 #                 DNS-01 for private). Default for OSS / testing.
 #                 Auto-renewing. Requires ACME_EMAIL.
 #   akv         — AKV-registered issuer + bicep cert deployment script
-#                 (BYO CA). Required for EV2 and any closed-network
+#                 (BYO CA). Required for the enterprise path and any closed-network
 #                 deployment. Requires PORTAL_TLS_ISSUER_NAME pointing at
 #                 a registered issuer (see akv-certificate-issuer.bicep).
 # Self-signed is no longer supported on the deploy path. For local

--- a/deploy/gitops/.gitignore
+++ b/deploy/gitops/.gitignore
@@ -1,6 +1,6 @@
 # The repo-level `.gitignore` excludes all `.env` files to prevent
 # credentials from leaking. The overlay `.env` files here are
-# committed templates (placeholder content only; FR-009). EV2
+# committed templates (placeholder content only; FR-009). The enterprise path
 # renders real values into them at rollout. Un-ignore just these
 # paths.
 !worker/overlays/default/.env

--- a/deploy/gitops/pls-anchor/base/ingress.yaml
+++ b/deploy/gitops/pls-anchor/base/ingress.yaml
@@ -11,8 +11,7 @@
 # AGIC itself owns, AGIC keeps the listener alive forever, and the hidden
 # PLS persists for Front Door's PE to attach to.
 #
-# Reference: postgresql-fleet-manager
-# `src/Deploy/BaseInfra/geneva-manifests/base/pls-anchor-ingress.yaml`
+# Adapted from an internal reference deployment.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/deploy/gitops/pls-anchor/base/ingress.yaml
+++ b/deploy/gitops/pls-anchor/base/ingress.yaml
@@ -1,0 +1,34 @@
+# PLS anchor Ingress — tells AGIC to create a listener on the AppGw
+# private frontend IP. This is the resource that solves the chicken-and-egg
+# problem: for Azure to materialise the hidden Private Link Service backing
+# the AppGw `privateLinkConfiguration`, the AppGw must have at least one
+# httpListener bound to the private frontend IP that references the PLC.
+# A `privateLinkConfigurations` block alone is not sufficient.
+#
+# AGIC owns the httpListeners array on the AppGw and re-PUTs it on every
+# reconcile. Bicep cannot durably write a private-FE listener — AGIC
+# overwrites it. By packaging the private-FE listener as an Ingress that
+# AGIC itself owns, AGIC keeps the listener alive forever, and the hidden
+# PLS persists for Front Door's PE to attach to.
+#
+# Reference: postgresql-fleet-manager
+# `src/Deploy/BaseInfra/geneva-manifests/base/pls-anchor-ingress.yaml`
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: pls-anchor-ingress
+  namespace: pls-anchor-system
+  annotations:
+    kubernetes.io/ingress.class: azure/application-gateway
+    appgw.ingress.kubernetes.io/use-private-ip: "true"
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /pls-health
+            pathType: Prefix
+            backend:
+              service:
+                name: pls-anchor
+                port:
+                  number: 80

--- a/deploy/gitops/pls-anchor/base/kustomization.yaml
+++ b/deploy/gitops/pls-anchor/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# pls-anchor base — the namespace + empty Service + private-FE Ingress
+# that anchor an AGIC-managed listener on the AppGw private frontend.
+# The Ingress is the durability mechanism for the hidden Private Link
+# Service that Front Door's PE attaches to. Same shape every stamp; the
+# FluxConfiguration in deploy/services/pls-anchor/bicep/main.bicep points
+# at overlays/default which simply re-exports this base.
+
+resources:
+  - namespace.yaml
+  - service.yaml
+  - ingress.yaml

--- a/deploy/gitops/pls-anchor/base/namespace.yaml
+++ b/deploy/gitops/pls-anchor/base/namespace.yaml
@@ -1,0 +1,10 @@
+# pls-anchor namespace.
+#
+# Hosts the empty Service + Ingress that anchor an AGIC-managed listener
+# on the AppGw private frontend IP. See ingress.yaml for the full story.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pls-anchor-system
+  labels:
+    name: pls-anchor-system

--- a/deploy/gitops/pls-anchor/base/service.yaml
+++ b/deploy/gitops/pls-anchor/base/service.yaml
@@ -1,0 +1,20 @@
+# PLS anchor Service — exists solely as an Ingress backend reference.
+# No pods match this selector; the empty backend pool is fine because AGIC
+# creates the AppGw listener from the Ingress object regardless of backend
+# health. The listener on the private frontend IP is what triggers
+# Azure to materialise the hidden Private Link Service that Front Door
+# attaches its Private Endpoint to.
+apiVersion: v1
+kind: Service
+metadata:
+  name: pls-anchor
+  namespace: pls-anchor-system
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 80
+  selector:
+    app: pls-anchor

--- a/deploy/gitops/pls-anchor/overlays/default/.env
+++ b/deploy/gitops/pls-anchor/overlays/default/.env
@@ -1,0 +1,5 @@
+# pls-anchor overlay carries no env-specific values. This file exists
+# only because the deploy pipeline's stage-manifests step requires every
+# overlay directory to ship a `.env` (substitute-env.mjs runs unconditionally
+# per overlay). The configMapGenerator in this overlay's kustomization is
+# intentionally absent, so the empty `.env` is never read by kustomize.

--- a/deploy/gitops/pls-anchor/overlays/default/kustomization.yaml
+++ b/deploy/gitops/pls-anchor/overlays/default/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+# pls-anchor has no env-specific knobs — the namespace, service, and Ingress
+# are identical across stamps. The overlay exists only to satisfy the deploy
+# pipeline's stage-manifests contract (every service has an `overlays/<env>/`
+# dir with a `.env` file) and to give the FluxConfiguration a stable
+# `overlays/<env>` path matching worker/portal.
+resources:
+  - ../../base

--- a/deploy/gitops/portal/base/kustomization.yaml
+++ b/deploy/gitops/portal/base/kustomization.yaml
@@ -7,7 +7,7 @@ kind: Kustomization
 # values, NO configMapGenerator, and NO replacements. All env-driven
 # wiring lives in the overlay so that the overlay's freshly-created
 # ConfigMap is the single source of truth for replacements (matches
-# the postgresql-fleet-manager reference pattern). See the worker
+# the reference deployment pattern). See the worker
 # base/kustomization.yaml for the full rationale.
 
 resources:

--- a/deploy/gitops/portal/overlays/afd-akv/kustomization.yaml
+++ b/deploy/gitops/portal/overlays/afd-akv/kustomization.yaml
@@ -12,7 +12,7 @@ namespace: pilotswarm
 # (Private Link). AKV-managed cert (issued by a registered issuer such
 # as `OneCertV2-PublicCA` or the AKV `Self` issuer for OSS) is pushed to
 # the AppGw via Bicep and bound by AGIC via the
-# `appgw-ssl-certificate` annotation contributed by edge-appgw. EV2 /
+# `appgw-ssl-certificate` annotation contributed by edge-appgw. The enterprise path /
 # enterprise public path.
 
 resources:

--- a/deploy/gitops/worker/base/kustomization.yaml
+++ b/deploy/gitops/worker/base/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 # resource (including the generated ConfigMaps in this base and in
 # the overlay). This matches the
 # [official kustomize `namespace:` semantics][1] and the
-# `postgresql-fleet-manager` reference pattern. It also keeps
+# `reference deployment` reference pattern. It also keeps
 # `nameReference` rewriting (volume.configMap.name → hashed name)
 # working without the namespace-mismatch trap.
 #

--- a/deploy/gitops/worker/base/kustomization.yaml
+++ b/deploy/gitops/worker/base/kustomization.yaml
@@ -9,7 +9,7 @@ kind: Kustomization
 # resource (including the generated ConfigMaps in this base and in
 # the overlay). This matches the
 # [official kustomize `namespace:` semantics][1] and the
-# `reference deployment` reference pattern. It also keeps
+# upstream reference deployment pattern. It also keeps
 # `nameReference` rewriting (volume.configMap.name → hashed name)
 # working without the namespace-mismatch trap.
 #

--- a/deploy/gitops/worker/overlays/default/kustomization.yaml
+++ b/deploy/gitops/worker/overlays/default/kustomization.yaml
@@ -7,10 +7,8 @@ kind: Kustomization
 # future variants (e.g. private-egress, alt-storage backend) slot in
 # as additional components alongside it.
 
-# Namespace re-asserted at the overlay level (matches the
-# `postgresql-fleet-manager` reference pattern: see
-# `src/Deploy/PostgreSQLFleetManager/manifests/overlays/dev/kustomization.yaml`
-# in that repo). This is required so the overlay-generated `worker-env`
+# Namespace re-asserted at the overlay level (matches the upstream
+# reference pattern). This is required so the overlay-generated `worker-env`
 # ConfigMap is created in the same namespace as the base resources,
 # which lets `nameReference` rewrite `envFrom.configMapRef.name` to
 # the hashed form.

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -6,10 +6,10 @@ A multi-platform Node.js deploy driver for PilotSwarm on AKS that
 | Path | What it is | When to use |
 |---|---|---|
 | `scripts/deploy-aks.sh` | Imperative bash script targeting an existing dev cluster (`docs/deploying-to-aks.md`). | Engineer smoke loop on a one-off cluster. |
-| `deploy/services/ev2-deploy-dev.ps1` | EV2-driven GitOps deploy (Bicep + Kustomize + Flux Storage Bucket, see `docs/deploying-to-aks-ev2.md`). | Production rollouts via the internal EV2 service. |
-| **`deploy/scripts/deploy.mjs`** *(this README)* | OSS-friendly equivalent of the EV2 path, runnable from any contributor's box without EV2. | Reproducing the GitOps deploy locally; future GitHub Actions wrapper. |
+| _enterprise deployment orchestrator_ (internal-only) | Enterprise-driven GitOps deploy (Bicep + Kustomize + Flux Storage Bucket). | Production rollouts via the enterprise deployment path. |
+| **`deploy/scripts/deploy.mjs`** *(this README)* | OSS-friendly equivalent of the enterprise path, runnable from any contributor's box without the enterprise path. | Reproducing the GitOps deploy locally; future GitHub Actions wrapper. |
 
-Same outcome as the EV2 path: Bicep deployed → image pushed to ACR →
+Same outcome as the enterprise path: Bicep deployed → image pushed to ACR →
 Kustomize manifests staged with `.env` substitution → tree uploaded to
 the Flux Storage Bucket → rollout verified against the running cluster.
 
@@ -48,7 +48,7 @@ npm run deploy:new-env
 npm run deploy:new-env -- foo --subscription <id> --location westus3
 #    The scaffolder generates RESOURCE_GROUP, GLOBAL_RESOURCE_PREFIX,
 #    GLOBAL_RESOURCE_GROUP, PORTAL_RESOURCE_NAME using the same patterns
-#    EV2 uses (deploy/services/<svc>/Ev2*Deployment/serviceModel.json):
+// The enterprise path uses (the enterprise deployment manifests):
 #      RESOURCE_GROUP         = ${RESOURCE_PREFIX}-<regionShort>-rg
 #      GLOBAL_RESOURCE_PREFIX = ${RESOURCE_PREFIX}global
 #      GLOBAL_RESOURCE_GROUP  = ${GLOBAL_RESOURCE_PREFIX}
@@ -63,12 +63,12 @@ npm run deploy -- baseinfra foo --steps bicep
 ```
 
 The reserved labels `dev` and `prod` are NOT valid OSS env names — they
-are used by the EV2 path for ServiceGroup naming.
+are used by the enterprise path for ServiceGroup naming.
 
 ### First-time bring-up (`all`)
 
 For an end-to-end deploy on a fresh subscription / cluster, use the `all`
-aggregate. It runs the canonical EV2-equivalent sequence
+aggregate. It runs the canonical enterprise-equivalent sequence
 (`globalinfra → baseinfra → worker → portal`) in a single invocation,
 sharing the same env map across services so Bicep outputs (ACR login
 server, deployment storage account, etc.) cascade forward automatically:
@@ -155,7 +155,7 @@ deployment-target keys, prompts for per-stamp secrets, and writes the
 complete file under `local/<name>/env`. Subsequent edits to `template.env`
 affect only newly-scaffolded envs — never existing ones.
 
-`dev` and `prod` are reserved labels used by the EV2 path for ServiceGroup
+`dev` and `prod` are reserved labels used by the enterprise path for ServiceGroup
 naming; they are NOT valid OSS env names.
 
 Files are flat `KEY=value`, no quoting, no shell expansion.
@@ -188,13 +188,13 @@ split-step runs (e.g. `worker dev --steps manifests` without first running
 `--steps bicep` in the same process) fail fast with a clear "unresolved
 placeholder" error directing you to run a prior `--steps bicep`.
 
-## How `.env` substitution works (vs. EV2)
+## How `.env` substitution works (vs. The enterprise path)
 
-| | EV2 path | OSS path |
+| | Enterprise path | OSS path |
 |---|---|---|
 | Source | `*.Configuration.json` per service | `deploy/envs/local/<name>/env` (standalone, scaffolded from `deploy/envs/template.env`) |
-| Scope binding | EV2 RP injects subscription / region / IDs into the parameters JSON | `deploy/scripts/lib/common.mjs` resolves env file → JS Map |
-| `.env` substitution | `GenerateEnvForEv2.ps1` rewrites overlay `.env` from JSON params | `deploy/scripts/lib/substitute-env.mjs` rewrites overlay `.env` from the env map |
+| Scope binding | the enterprise orchestrator injects subscription / region / IDs into the parameters JSON | `deploy/scripts/lib/common.mjs` resolves env file → JS Map |
+| `.env` substitution | the enterprise param-substitution helper rewrites overlay `.env` from JSON params | `deploy/scripts/lib/substitute-env.mjs` rewrites overlay `.env` from the env map |
 | Per-service identity | Per-service scope binding | Shared `csiIdentity` UAMI clientId cascades from BaseInfra Bicep output → both worker and portal overlays |
 
 Both paths produce the **same rendered overlay `.env`** before upload.
@@ -384,6 +384,6 @@ hard-code the URL.
 
 ## Cross-references
 
-- EV2 / production path: [`docs/deploying-to-aks-ev2.md`](../../docs/deploying-to-aks-ev2.md)
+- Enterprise / production path: handled by an internal-only orchestrator (out of scope for this OSS repo)
 - Imperative engineer-smoke path: [`docs/deploying-to-aks.md`](../../docs/deploying-to-aks.md)
 - Spec / plan / as-built record: [`.paw/work/oss-deploy-script/`](../../.paw/work/oss-deploy-script/)

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -48,7 +48,7 @@ npm run deploy:new-env
 npm run deploy:new-env -- foo --subscription <id> --location westus3
 #    The scaffolder generates RESOURCE_GROUP, GLOBAL_RESOURCE_PREFIX,
 #    GLOBAL_RESOURCE_GROUP, PORTAL_RESOURCE_NAME using the same patterns
-// The enterprise path uses (the enterprise deployment manifests):
+#    that the enterprise deployment manifests use:
 #      RESOURCE_GROUP         = ${RESOURCE_PREFIX}-<regionShort>-rg
 #      GLOBAL_RESOURCE_PREFIX = ${RESOURCE_PREFIX}global
 #      GLOBAL_RESOURCE_GROUP  = ${GLOBAL_RESOURCE_PREFIX}

--- a/deploy/scripts/deploy.mjs
+++ b/deploy/scripts/deploy.mjs
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
 // OSS Node deploy orchestrator entry point (Phase 1 skeleton).
 //
-// Drives the same end-state as deploy/services/ev2-deploy-dev.ps1 (Bicep + image push +
-// Flux Storage Bucket manifest delivery + rollout verify) without any EV2 dependency.
+// Drives the same end-state as the enterprise deployment orchestrator (Bicep + image push +
+// Flux Storage Bucket manifest delivery + rollout verify) without any enterprise dependency.
 //
 // Stdlib-only Node, no shell:true, multi-platform (Windows / macOS / Linux).
 // Spec: .paw/work/oss-deploy-script/Spec.md
@@ -93,7 +93,7 @@ function parseArgs(argv) {
 function printHelp() {
   process.stdout.write(
     [
-      "OSS Node deploy orchestrator for PilotSwarm (additive to EV2 path).",
+      "OSS Node deploy orchestrator for PilotSwarm (additive to enterprise path).",
       "",
       "Usage:",
       "  npm run deploy -- <service> <env> [flags]",
@@ -102,7 +102,7 @@ function printHelp() {
       "           ('all' runs the canonical end-to-end sequence:",
       "            globalinfra → baseinfra → cert-manager → cert-manager-issuers → worker → portal,",
       "            applying --steps to each as appropriate. cert-manager services",
-      "            are skipped on the akv (EV2) TLS_SOURCE path.)",
+      "            are skipped on the akv (enterprise) TLS_SOURCE path.)",
       "Envs:      a local env name created with `npm run deploy:new-env`",
       "",
       "Flags:",
@@ -350,7 +350,7 @@ async function main() {
   }
 
   // cert-manager + cert-manager-issuers ship the OSS Let's Encrypt path.
-  // Skip them entirely when TLS_SOURCE != letsencrypt (EV2 / akv path).
+  // Skip them entirely when TLS_SOURCE != letsencrypt (enterprise / akv path).
   if (
     (service === "cert-manager" || service === "cert-manager-issuers") &&
     tlsSource !== "letsencrypt"
@@ -401,7 +401,7 @@ async function main() {
   }
   // TLS_SOURCE=akv no longer requires a pre-set PORTAL_TLS_ISSUER_NAME —
   // Portal bicep now defaults it to OneCertV2-PublicCA (afd) or
-  // OneCertV2-PrivateCA (private) per the postgresql-fleet-manager pattern
+  // OneCertV2-PrivateCA (private) per the reference deployment pattern
   // and registers the issuer on the AKV automatically. Operators can still
   // override via env if they want a different registered CA.
   // TLS_SOURCE=akv-selfsigned uses the AKV built-in `Self` issuer; no
@@ -539,7 +539,7 @@ async function runAll({ envName, env, steps, imageTag, clean, force, edgeMode })
   // Drop globalinfra from the sequence when AFD is disabled — the service is
   // entirely AFD provisioning and would otherwise create an empty RG with no
   // resources. Mirrors the single-service short-circuit above. cert-manager
-  // + cert-manager-issuers are dropped on the akv (EV2) path for the same
+  // + cert-manager-issuers are dropped on the akv (enterprise) path for the same
   // reason — those services exist only to serve the OSS Let's Encrypt path.
   const tlsSource = (env.TLS_SOURCE || "letsencrypt").toLowerCase();
   const sequence = ALL_SEQUENCE.filter(

--- a/deploy/scripts/deploy.mjs
+++ b/deploy/scripts/deploy.mjs
@@ -78,7 +78,7 @@ function parseArgs(argv) {
   if (positional.length < 2) {
     throw new Error(
       "Usage: npm run deploy -- <service> <env> [flags]\n" +
-        "  <service>    worker | portal | baseinfra | globalinfra | cert-manager | cert-manager-issuers | all\n" +
+        "  <service>    worker | portal | baseinfra | globalinfra | pls-anchor | cert-manager | cert-manager-issuers | all\n" +
         "  <env>        local env name created with `npm run deploy:new-env`\n" +
         "Flags: --steps, --region, --image-tag, --clean, --force, --help",
     );
@@ -98,11 +98,12 @@ function printHelp() {
       "Usage:",
       "  npm run deploy -- <service> <env> [flags]",
       "",
-      "Services:  worker | portal | baseinfra | globalinfra | cert-manager | cert-manager-issuers | all",
+      "Services:  worker | portal | baseinfra | globalinfra | pls-anchor | cert-manager | cert-manager-issuers | all",
       "           ('all' runs the canonical end-to-end sequence:",
-      "            globalinfra → baseinfra → cert-manager → cert-manager-issuers → worker → portal,",
-      "            applying --steps to each as appropriate. cert-manager services",
-      "            are skipped on the akv (enterprise) TLS_SOURCE path.)",
+      "            globalinfra → baseinfra → pls-anchor → cert-manager → cert-manager-issuers → worker → portal,",
+      "            applying --steps to each as appropriate. pls-anchor is skipped",
+      "            on the EDGE_MODE=private path; cert-manager services are skipped",
+      "            on the akv (enterprise) TLS_SOURCE path.)",
       "Envs:      a local env name created with `npm run deploy:new-env`",
       "",
       "Flags:",
@@ -362,6 +363,17 @@ async function main() {
     return;
   }
 
+  // pls-anchor anchors the AppGw private-FE listener that materialises the
+  // hidden Private Link Service backing AFD's Private Endpoint. With no AFD
+  // (EDGE_MODE != afd) there is no AppGw / no PE / nothing to anchor — skip.
+  if (service === "pls-anchor" && edgeMode !== "afd") {
+    log(
+      "ok",
+      `EDGE_MODE='${edgeMode}' — 'pls-anchor' is not provisioned in this mode (only on the AFD edge path). Nothing to do.`,
+    );
+    return;
+  }
+
   // 4b) Mode-specific pre-deploy validation.
   if (edgeMode === "private") {
     if (!env.HOST || env.HOST.trim() === "") {
@@ -544,6 +556,8 @@ async function runAll({ envName, env, steps, imageTag, clean, force, edgeMode })
   const tlsSource = (env.TLS_SOURCE || "letsencrypt").toLowerCase();
   const sequence = ALL_SEQUENCE.filter(
     (svc) => !(svc === "global-infra" && edgeMode !== "afd"),
+  ).filter(
+    (svc) => !(svc === "pls-anchor" && edgeMode !== "afd"),
   ).filter(
     (svc) =>
       !((svc === "cert-manager" || svc === "cert-manager-issuers") && tlsSource !== "letsencrypt"),

--- a/deploy/scripts/lib/build-image.mjs
+++ b/deploy/scripts/lib/build-image.mjs
@@ -2,7 +2,7 @@
 //
 // docker buildx build --platform linux/amd64 --load → docker save → in-process
 // zlib gzip → <staging>/<dockerImageRepo>.tar.gz. Output filename matches
-// EV2's <repo>.tar.gz (CodeResearch Q4) so downstream tooling sees the same shape.
+// The enterprise path's <repo>.tar.gz (CodeResearch Q4) so downstream tooling sees the same shape.
 
 import { spawn } from "node:child_process";
 import { createWriteStream, existsSync } from "node:fs";

--- a/deploy/scripts/lib/common.mjs
+++ b/deploy/scripts/lib/common.mjs
@@ -62,7 +62,7 @@ export function parseEnvFile(path) {
 // onto the template, so future template edits affect only newly-
 // scaffolded envs — never existing ones.
 //
-// `dev` and `prod` are reserved labels (used by the EV2 path for
+// `dev` and `prod` are reserved labels (used by the enterprise path for
 // ServiceGroup naming via `$config(environment)`); they are NOT valid
 // OSS env names.
 //

--- a/deploy/scripts/lib/compose-env.mjs
+++ b/deploy/scripts/lib/compose-env.mjs
@@ -23,12 +23,12 @@ export function composeDerivedEnv(env) {
   // bicep-deploy path (see deploy/gitops/worker/base/secret-provider-class.yaml).
   // Embeds the deterministic bootstrap admin password from postgres.bicep.
   // The password is identical on every stamp and never reaches a real
-  // production cluster (prod uses the EV2 path, where Postgres comes with
+  // production cluster (prod uses the enterprise path, where Postgres comes with
   // AAD-only auth).
   if (!env.DATABASE_URL && env.POSTGRES_FQDN) {
     const pgUser = env.POSTGRES_ADMIN_LOGIN || "pilotswarm";
     const pgDb = env.POSTGRES_DATABASE_NAME || "pilotswarm";
-    const pgPwd = env.POSTGRES_ADMIN_PASSWORD || "PilotSwarmEv2_BootstrapOnly!9876";
+    const pgPwd = env.POSTGRES_ADMIN_PASSWORD || "PilotSwarmDev_BootstrapOnly!9876";
     env.DATABASE_URL = `postgresql://${pgUser}:${pgPwd}@${env.POSTGRES_FQDN}:5432/${pgDb}?sslmode=require`;
     log("info", `Composed DATABASE_URL for overlay from POSTGRES_FQDN.`);
   }

--- a/deploy/scripts/lib/deploy-bicep.mjs
+++ b/deploy/scripts/lib/deploy-bicep.mjs
@@ -56,7 +56,7 @@ const OUTPUT_ALIAS = {
   // deployment script. Cascades into Portal.params.template.json.
   approverIdentityResourceId: "APPROVAL_MANAGED_IDENTITY_ID",
   // Portal bicep emits the canonical AFD/AppGw/Ingress hostname as
-  // `BackendHostName` (Pascal-case for EV2 scope-binding parity). Aliased
+  // `BackendHostName` (Pascal-case for the enterprise orchestrator's scope binding parity). Aliased
   // into `PORTAL_HOSTNAME` so the manifests step's overlay `.env`
   // substitution picks up the bicep-computed value (matching FM's
   // playgroundservice pattern where the same string is the cert subject,
@@ -143,8 +143,8 @@ async function deployOne({ moduleName, service, envName, env, region, stagingDir
   // module can grant Storage Blob Data Contributor to the running user at
   // create time (avoids the post-hoc role-assignment + RBAC propagation race
   // that every fresh stamp would otherwise hit on the manifests upload).
-  // EV2 doesn't pass this — its principal already has the role via the
-  // ev2-deploy UAMI assignment, and the Bicep param defaults to empty.
+  // The enterprise path doesn't pass this — its principal already has the role via the
+  // enterprise deploy UAMI assignment, and the Bicep param defaults to empty.
   if (moduleName === "base-infra") {
     const localPrincipal = resolveLocalDeploymentPrincipal();
     if (localPrincipal) {
@@ -281,7 +281,7 @@ async function deployOne({ moduleName, service, envName, env, region, stagingDir
 
 // Look up the AAD principal currently signed in to the Azure CLI and return
 // `{ id, type, label }` describing it, or `null` if we're not running as an
-// AAD user (e.g. service-principal logins like the EV2 deploy MID, which
+// AAD user (e.g. service-principal logins like the enterprise deploy MID, which
 // already has the role via Bicep — no extra grant needed).
 function resolveLocalDeploymentPrincipal() {
   // `az ad signed-in-user show` only succeeds for User-type logins; SPs
@@ -304,7 +304,7 @@ function resolveLocalDeploymentPrincipal() {
 }
 
 // Ensure the resource group exists before an RG-scoped deployment. Idempotent
-// (`az group create` is upsert semantics). EV2 normally provisions RGs via
+// (`az group create` is upsert semantics). The enterprise path normally provisions RGs via
 // rollout infrastructure; in the OSS path we make sure they exist here so
 // `az deployment group create` doesn't fail with ResourceGroupNotFound on a
 // fresh subscription.

--- a/deploy/scripts/lib/publish-manifests.mjs
+++ b/deploy/scripts/lib/publish-manifests.mjs
@@ -8,7 +8,7 @@
 // Uses `az storage blob upload-batch --auth-mode login` — caller must have
 // `Storage Blob Data Contributor` (or higher) on the storage account. The
 // BaseInfra Bicep module grants that role at storage-account creation time:
-//   - EV2 production runs:  granted to the EV2 deploy UAMI (ev2-deploy-rbac.bicep)
+//   - enterprise / production runs:  granted to the enterprise deploy UAMI (enterprise-deploy-rbac.bicep)
 //   - Local `npm run deploy`: granted to the signed-in AAD user (storage.bicep
 //     conditional role assignment, driven by the `localDeploymentPrincipalId`
 //     param that deploy-bicep.mjs populates from `az ad signed-in-user`).

--- a/deploy/scripts/lib/services-manifest.mjs
+++ b/deploy/scripts/lib/services-manifest.mjs
@@ -6,7 +6,7 @@
 // invariant that every name in {infraOrder ∪ services} has a matching
 // deploy.json file.
 //
-// Distinct from the EV2 services.json / service.json files that live alongside
+// Distinct from the enterprise services.json / service.json files that live alongside
 // these in deploy/services/. Those will be migrated to a parent repo via
 // submodule; this loader never touches them.
 

--- a/deploy/scripts/new-env.mjs
+++ b/deploy/scripts/new-env.mjs
@@ -9,7 +9,7 @@
 //
 // Creates `deploy/envs/local/<name>/env` by copying `deploy/envs/template.env`
 // and substituting deployment-target keys using the same naming patterns
-// EV2 uses (deploy/services/<svc>/Ev2*Deployment/serviceModel.json):
+// The enterprise path uses (the enterprise deployment manifests):
 //
 //   • resourcePrefix       = ps<name>
 //   • azureResourceGroup   = ${resourcePrefix}-${regionShortName}-rg
@@ -64,7 +64,7 @@ const DEFAULT_EDGE_MODE = "afd";
 //                    edgeMode=afd. OSS public default.
 //   akv            — AKV-registered issuer (e.g. OneCertV2-PublicCA for afd,
 //                    OneCertV2-PrivateCA for private) + bicep cert deployment
-//                    script. EV2 / enterprise / AME path.
+//                    script. enterprise / closed-network path.
 //   akv-selfsigned — AKV `Self` issuer; bicep auto-creates a self-signed cert
 //                    in AKV with SAN=${HOST}.${PRIVATE_DNS_ZONE}. Only valid
 //                    with edgeMode=private. OSS private demo path; zero
@@ -299,7 +299,7 @@ export const INPUTS = [
       letsencrypt: "cert-manager + Let's Encrypt prod (HTTP-01, auto-renew, OSS public default)",
       akv:
         ctx.edgeMode === "afd"
-          ? "AKV-registered OneCertV2-PublicCA issuer + bicep cert deploy (EV2 / enterprise public)"
+          ? "AKV-registered OneCertV2-PublicCA issuer + bicep cert deploy (enterprise public)"
           : "AKV-registered OneCertV2-PrivateCA issuer + bicep cert deploy (AME / enterprise private)",
       "akv-selfsigned": "AKV `Self` issuer; bicep auto-creates a self-signed cert (OSS private demo)",
     }),
@@ -468,7 +468,7 @@ function usage() {
   return lines.join("\n");
 }
 
-// Derive deployment-target values from a small set of inputs, matching EV2
+// Derive deployment-target values from a small set of inputs, matching the enterprise path
 // serviceModel.json naming patterns. Pure function — no I/O.
 export function deriveTargets({ name, subscription, location, regionShort, edgeMode, host, privateDnsZone, portalHostname, tlsSource, acmeEmail, foundryEnabled }) {
   const prefix = `ps${name}`;
@@ -850,7 +850,7 @@ async function main() {
   }
 
   console.log("");
-  console.log(`Generated deployment targets (EV2 naming pattern):`);
+  console.log(`Generated deployment targets (enterprise naming pattern):`);
   for (const [k, v] of Object.entries(targets)) console.log(`  ${k}=${v}`);
   console.log("");
   console.log(`Next steps:`);

--- a/deploy/scripts/test/all-mode.test.mjs
+++ b/deploy/scripts/test/all-mode.test.mjs
@@ -14,11 +14,11 @@ import { ALL_SEQUENCE, ALL_MODE_MODULES, SERVICE_TO_MODULES } from "../lib/servi
 import { defaultPipelineFor, resolveSteps } from "../lib/stages.mjs";
 import { validateService, ALL_SERVICE, SERVICES } from "../lib/common.mjs";
 
-test("ALL_SEQUENCE matches EV2 services.json infraOrder + service order", () => {
-  // EV2 deploy/services/services.json: infraOrder = ["GlobalInfra","BaseInfra"], then
+test("ALL_SEQUENCE matches the enterprise services.json infraOrder + service order", () => {
+  // The enterprise path deploy/services/services.json: infraOrder = ["GlobalInfra","BaseInfra"], then
   // services Worker, Portal. The OSS aggregate mirrors that ordering and
   // appends cert-manager + cert-manager-issuers (OSS-only Let's Encrypt
-  // path; EV2 stays on the akv path and skips them via deploy.mjs).
+  // path; the enterprise path stays on the akv path and skips them via deploy.mjs).
   assert.deepEqual(ALL_SEQUENCE, [
     "global-infra",
     "base-infra",

--- a/deploy/scripts/test/all-mode.test.mjs
+++ b/deploy/scripts/test/all-mode.test.mjs
@@ -22,6 +22,7 @@ test("ALL_SEQUENCE matches the enterprise services.json infraOrder + service ord
   assert.deepEqual(ALL_SEQUENCE, [
     "global-infra",
     "base-infra",
+    "pls-anchor",
     "cert-manager",
     "cert-manager-issuers",
     "worker",
@@ -41,6 +42,7 @@ test("ALL_MODE_MODULES has exactly one module per service (no redundant redeploy
   assert.equal(ALL_MODE_MODULES.portal[0], SERVICE_TO_MODULES.portal.at(-1));
   assert.equal(ALL_MODE_MODULES["base-infra"][0], "base-infra");
   assert.equal(ALL_MODE_MODULES["global-infra"][0], "global-infra");
+  assert.equal(ALL_MODE_MODULES["pls-anchor"][0], "pls-anchor");
   assert.equal(ALL_MODE_MODULES["cert-manager"][0], "cert-manager");
   assert.equal(ALL_MODE_MODULES["cert-manager-issuers"][0], "cert-manager-issuers");
 });
@@ -60,7 +62,7 @@ test("validateService accepts 'all' as a virtual aggregate", () => {
   // current set so accidental removals are caught.
   assert.deepEqual(
     [...SERVICES].sort(),
-    ["base-infra", "cert-manager", "cert-manager-issuers", "global-infra", "portal", "worker"],
+    ["base-infra", "cert-manager", "cert-manager-issuers", "global-infra", "pls-anchor", "portal", "worker"],
   );
 });
 
@@ -81,10 +83,10 @@ test("step intersection: --steps manifests,rollout skips infra-only services", (
     const effective = resolved.filter((s) => defaultPipelineFor(svc).includes(s));
     assert.deepEqual(effective, [], `${svc} should be skipped for app-only steps`);
   }
-  // cert-manager / cert-manager-issuers are infra-kind but DO publish manifests
+  // pls-anchor / cert-manager / cert-manager-issuers are infra-kind but DO publish manifests
   // (their pipeline override is [bicep, manifests]) — manifests survives the
   // intersection, rollout does not.
-  for (const svc of ["cert-manager", "cert-manager-issuers"]) {
+  for (const svc of ["pls-anchor", "cert-manager", "cert-manager-issuers"]) {
     const resolved = resolveSteps("manifests,rollout", svc);
     const effective = resolved.filter((s) => defaultPipelineFor(svc).includes(s));
     assert.deepEqual(effective, ["manifests"], `${svc} should publish manifests but not rollout`);
@@ -101,6 +103,7 @@ test("default (no --steps) full all-mode runs full pipeline for app services, bi
   const expected = {
     "global-infra": ["bicep"],
     "base-infra": ["bicep", "seed-secrets"],
+    "pls-anchor": ["bicep", "manifests"],
     "cert-manager": ["bicep", "manifests"],
     "cert-manager-issuers": ["bicep", "manifests"],
     worker: ["build", "bicep", "push", "manifests", "rollout"],

--- a/deploy/scripts/test/compose-env.test.mjs
+++ b/deploy/scripts/test/compose-env.test.mjs
@@ -12,7 +12,7 @@ test("composes DATABASE_URL from POSTGRES_FQDN with bootstrap defaults", () => {
   composeDerivedEnv(env);
   assert.equal(
     env.DATABASE_URL,
-    "postgresql://pilotswarm:PilotSwarmEv2_BootstrapOnly!9876@ps.example.postgres.database.azure.com:5432/pilotswarm?sslmode=require",
+    "postgresql://pilotswarm:PilotSwarmDev_BootstrapOnly!9876@ps.example.postgres.database.azure.com:5432/pilotswarm?sslmode=require",
   );
 });
 

--- a/deploy/scripts/test/new-env.test.mjs
+++ b/deploy/scripts/test/new-env.test.mjs
@@ -34,7 +34,7 @@ const FULL_ARGS = (name = TEST_NAME) => [
   "westus3",
 ];
 
-test("deriveTargets follows EV2 naming patterns", () => {
+test("deriveTargets follows enterprise naming patterns", () => {
   const t = deriveTargets({
     name: "foo",
     subscription: "sub-id",

--- a/deploy/scripts/test/services-manifest.test.mjs
+++ b/deploy/scripts/test/services-manifest.test.mjs
@@ -32,6 +32,7 @@ test("real manifest loads and matches the canonical service shape", () => {
   assert.deepEqual(m.allSequence, [
     "global-infra",
     "base-infra",
+    "pls-anchor",
     "cert-manager",
     "cert-manager-issuers",
     "worker",
@@ -39,6 +40,7 @@ test("real manifest loads and matches the canonical service shape", () => {
   ]);
   assert.equal(m.services.worker.kind, "app");
   assert.equal(m.services["base-infra"].kind, "infra");
+  assert.equal(m.services["pls-anchor"].kind, "infra");
   assert.equal(m.services["cert-manager"].kind, "infra");
   assert.equal(m.services["cert-manager-issuers"].kind, "infra");
   assert.equal(m.regionShort.westus3, "wus3");
@@ -49,6 +51,7 @@ test("derived constants match prior hardcoded shape (regression contract)", () =
   assert.deepEqual(ALL_SEQUENCE, [
     "global-infra",
     "base-infra",
+    "pls-anchor",
     "cert-manager",
     "cert-manager-issuers",
     "worker",
@@ -65,6 +68,7 @@ test("derived constants match prior hardcoded shape (regression contract)", () =
   assert.deepEqual(SERVICE_TO_MODULES.portal, ["base-infra", "portal"]);
   assert.deepEqual(SERVICE_TO_MODULES["base-infra"], ["base-infra"]);
   assert.deepEqual(SERVICE_TO_MODULES["global-infra"], ["global-infra"]);
+  assert.deepEqual(SERVICE_TO_MODULES["pls-anchor"], ["base-infra", "pls-anchor"]);
   assert.deepEqual(SERVICE_TO_MODULES["cert-manager"], ["base-infra", "cert-manager"]);
   assert.deepEqual(SERVICE_TO_MODULES["cert-manager-issuers"], ["base-infra", "cert-manager-issuers"]);
 
@@ -73,6 +77,7 @@ test("derived constants match prior hardcoded shape (regression contract)", () =
   assert.equal(MODULE_SCOPE["base-infra"], "group");
   assert.equal(MODULE_SCOPE.worker, "group");
   assert.equal(MODULE_SCOPE.portal, "group");
+  assert.equal(MODULE_SCOPE["pls-anchor"], "group");
   assert.equal(MODULE_SCOPE["cert-manager"], "group");
   assert.equal(MODULE_SCOPE["cert-manager-issuers"], "group");
 

--- a/deploy/services/base-infra/bicep/agic-rbac.bicep
+++ b/deploy/services/base-infra/bicep/agic-rbac.bicep
@@ -7,7 +7,7 @@
 // THAT identity, not the AKS control-plane UAMI, so the addon identity needs
 // explicit role grants to manage the BYO Application Gateway.
 //
-// Mirrors postgresql-fleet-manager `agic-appgw-rbac.bicep` + `agic-vnet-rbac.bicep`
+// Mirrors reference deployment patterns: `agic-vnet-rbac.bicep`
 // combined into one module:
 //   1. Contributor on the Application Gateway — required to mutate AppGw config
 //      when Ingress objects change.

--- a/deploy/services/base-infra/bicep/aks-container-insights-dcr.bicep
+++ b/deploy/services/base-infra/bicep/aks-container-insights-dcr.bicep
@@ -6,7 +6,7 @@
 // (retiring 2026-09-30), so new clusters should opt into ContainerLogV2
 // from day one.
 //
-// Ported from postgresql-fleet-manager
+// Ported from reference deployment
 // (src/Deploy/BaseInfra/bicep/aks-container-insights-dcr.bicep). No
 // PilotSwarm-specific changes — the fleet pattern is already minimal.
 //

--- a/deploy/services/base-infra/bicep/aks.bicep
+++ b/deploy/services/base-infra/bicep/aks.bicep
@@ -235,7 +235,7 @@ resource assignMiOperatorToCluster 'Microsoft.Authorization/roleAssignments@2022
 
 // ---------------------------------------------------------------------------
 // Flux extension. Uses the kubelet identity for Azure Blob authentication,
-// matching the approach in the fleet-manager reference (the Flux Azure Blob
+// matching the approach in the reference deployment (the Flux Azure Blob
 // source controller does not yet support workload identity).
 // ---------------------------------------------------------------------------
 resource fluxExtension 'Microsoft.KubernetesConfiguration/extensions@2023-05-01' = {

--- a/deploy/services/base-infra/bicep/application-gateway-existing.bicep
+++ b/deploy/services/base-infra/bicep/application-gateway-existing.bicep
@@ -9,7 +9,7 @@
 //
 // This module exists as a separate file because Bicep doesn't allow an
 // `existing` reference to the same resource a sibling module is declaring
-// (that would produce a self-dependency). Mirrors postgresql-fleet-manager
+// (that would produce a self-dependency). Mirrors reference deployment
 // `application-gateway-existing.bicep`.
 //
 // Consumed by `application-gateway.bicep` via a ternary-with-`!` pattern,

--- a/deploy/services/base-infra/bicep/application-gateway.bicep
+++ b/deploy/services/base-infra/bicep/application-gateway.bicep
@@ -4,7 +4,7 @@
 //
 // The `privateLinkConfigurations` block and the private frontend IP binding
 // are adapted verbatim from
-//   postgresql-fleet-manager/src/Deploy/BaseInfra/bicep/application-gateway.bicep:270-309
+//   an internal reference deployment
 // The rest of the module is simplified: no AGIC preservation of existing
 // pools/listeners/rules (PilotSwarm rolls out from a clean state per region
 // under GitOps; AGIC repopulates these after the FluxConfig reconciles).
@@ -35,7 +35,7 @@ param wafMode string = 'Prevention'
 @description('Availability zones for the App Gateway. Empty array disables zone placement.')
 param availabilityZones array = []
 
-@description('Resource ID of the user-assigned managed identity attached to the Application Gateway. Required so the AGIC addon can hold the "Managed Identity Operator" role on this UAMI (mirrors postgresql-fleet-manager pattern).')
+@description('Resource ID of the user-assigned managed identity attached to the Application Gateway. Required so the AGIC addon can hold the "Managed Identity Operator" role on this UAMI (mirrors reference deployment pattern).')
 param userAssignedIdentityId string
 
 @description('Whether the Application Gateway already exists in this RG. When true, AGIC-managed arrays (pools, listeners, rules, probes, etc.) are read back from the existing resource and re-emitted unchanged so we do not clobber AGIC\'s runtime config. Driven by check-appgw-exists.bicep.')
@@ -134,7 +134,7 @@ resource publicIp 'Microsoft.Network/publicIPAddresses@2024-01-01' = {
 }
 
 // ---------------------------------------------------------------------------
-// AGIC config preservation (postgresql-fleet-manager pattern).
+// AGIC config preservation (reference deployment pattern).
 // ---------------------------------------------------------------------------
 // AGIC dynamically manages backendAddressPools, httpListeners, requestRoutingRules,
 // probes, urlPathMaps, redirectConfigurations, rewriteRuleSets, frontendPorts,
@@ -415,7 +415,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2024-01-01' =
     ]
     // Private Link configuration for Front Door connectivity — must be
     // defined before frontendIPConfigurations. Adapted verbatim from
-    // postgresql-fleet-manager application-gateway.bicep:270-309.
+    // reference deployment application-gateway.bicep:270-309.
     privateLinkConfigurations: [
       {
         name: 'privateLinkConfig'

--- a/deploy/services/base-infra/bicep/application-gateway.bicep
+++ b/deploy/services/base-infra/bicep/application-gateway.bicep
@@ -209,6 +209,30 @@ var defaultHttpListeners = [
       protocol: 'Http'
     }
   }
+  // Private-FE listener seeded ONLY on first deploy. For Azure to materialise
+  // the hidden Private Link Service backing the privateLinkConfiguration, the
+  // AppGw must have at least one httpListener bound to the private frontend IP
+  // referencing the PLC; the privateLinkConfigurations block alone is not
+  // sufficient. After AGIC reconciles, the durable private-FE listener is
+  // owned by AGIC (via the `pls-anchor` Ingress in pls-anchor-system —
+  // deploy/services/pls-anchor) and is preserved unchanged on subsequent
+  // bicep deploys via the `appGwExists` read-back path below.
+  {
+    name: 'privateHttpListener'
+    properties: {
+      frontendIPConfiguration: {
+        id: resourceId(
+          'Microsoft.Network/applicationGateways/frontendIPConfigurations',
+          applicationGatewayName,
+          'appGatewayPrivateFrontendIP'
+        )
+      }
+      frontendPort: {
+        id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', applicationGatewayName, 'httpPort')
+      }
+      protocol: 'Http'
+    }
+  }
 ]
 
 var defaultRequestRoutingRules = [
@@ -240,132 +264,58 @@ var defaultRequestRoutingRules = [
       }
     }
   }
+  // Routing rule for the private-FE listener — required for the listener to
+  // be accepted by ARM. Only seeded on first deploy; AGIC owns the rule for
+  // the durable pls-anchor Ingress thereafter.
+  {
+    name: 'privateRoutingRule'
+    properties: {
+      priority: 200
+      ruleType: 'Basic'
+      httpListener: {
+        id: resourceId(
+          'Microsoft.Network/applicationGateways/httpListeners',
+          applicationGatewayName,
+          'privateHttpListener'
+        )
+      }
+      backendAddressPool: {
+        id: resourceId(
+          'Microsoft.Network/applicationGateways/backendAddressPools',
+          applicationGatewayName,
+          'defaultBackendPool'
+        )
+      }
+      backendHttpSettings: {
+        id: resourceId(
+          'Microsoft.Network/applicationGateways/backendHttpSettingsCollection',
+          applicationGatewayName,
+          'defaultBackendHttpSettings'
+        )
+      }
+    }
+  }
 ]
-
-// ---------------------------------------------------------------------------
-// Private Link Service bootstrap entries.
-//
-// For Azure to materialise the hidden Private Link Service backing the
-// AppGw privateLinkConfiguration (the `_<guid>_<appGwName>_<plcName>` PLS
-// that Front Door's PE consumes), the AppGw must have at least one
-// HTTP listener bound to the private frontend IP that references the
-// privateLinkConfiguration. A privateLinkConfigurations block alone is
-// not sufficient.
-//
-// AGIC reconciles AppGw config from K8s Ingress state and *removes*
-// listeners/rules it does not own. Its naming scheme uses prefixes
-// `fl-`/`rr-`/`bp-`/`bhs-`/`fp-`. The bootstrap entries below use a
-// `psPls`-prefixed naming scheme that AGIC will not touch, and they are
-// always concat'd into the effective arrays — including the existing
-// AGIC-managed read-back path — so the private listener survives every
-// re-deploy and the hidden PLS keeps existing.
-// ---------------------------------------------------------------------------
-var psPlsBootstrapPool = {
-  name: 'psPlsBootstrapPool'
-  properties: {
-    backendAddresses: []
-  }
-}
-
-var psPlsBootstrapSettings = {
-  name: 'psPlsBootstrapSettings'
-  properties: {
-    port: 80
-    protocol: 'Http'
-    cookieBasedAffinity: 'Disabled'
-    requestTimeout: 30
-    pickHostNameFromBackendAddress: false
-  }
-}
-
-var psPlsBootstrapListener = {
-  name: 'psPlsBootstrapListener'
-  properties: {
-    frontendIPConfiguration: {
-      id: resourceId(
-        'Microsoft.Network/applicationGateways/frontendIPConfigurations',
-        applicationGatewayName,
-        'appGatewayPrivateFrontendIP'
-      )
-    }
-    frontendPort: {
-      id: resourceId('Microsoft.Network/applicationGateways/frontendPorts', applicationGatewayName, 'httpPort')
-    }
-    protocol: 'Http'
-  }
-}
-
-var psPlsBootstrapRule = {
-  name: 'psPlsBootstrapRule'
-  properties: {
-    // High priority value (low precedence) within ARM's 1-20000 range to
-    // avoid colliding with AGIC's ingress rules, which start at small
-    // numbers.
-    priority: 20000
-    ruleType: 'Basic'
-    httpListener: {
-      id: resourceId(
-        'Microsoft.Network/applicationGateways/httpListeners',
-        applicationGatewayName,
-        'psPlsBootstrapListener'
-      )
-    }
-    backendAddressPool: {
-      id: resourceId(
-        'Microsoft.Network/applicationGateways/backendAddressPools',
-        applicationGatewayName,
-        'psPlsBootstrapPool'
-      )
-    }
-    backendHttpSettings: {
-      id: resourceId(
-        'Microsoft.Network/applicationGateways/backendHttpSettingsCollection',
-        applicationGatewayName,
-        'psPlsBootstrapSettings'
-      )
-    }
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Effective values: defaults on first deploy, AGIC-managed values on
 // subsequent deploys. Behind appGwExists; bang-suffix tells Bicep the
 // conditional module's outputs are non-null in this branch.
 //
-// PLS bootstrap entries (psPls*) are always concat'd onto the effective
-// arrays — filtered first to keep the deployment idempotent — so the
-// private-FE listener that materialises the hidden PLS survives every
-// AGIC reconciliation.
+// We do NOT augment the AGIC-read-back arrays in bicep. AGIC owns the
+// listeners/rules/pools and re-PUTs them on every reconcile; any entries we
+// append here would survive the bicep deploy but be wiped on AGIC's next
+// reconcile, leaving the AppGw in a flapping state. The durable private-FE
+// listener that materialises the hidden Private Link Service is anchored by
+// the `pls-anchor` Ingress in pls-anchor-system (deploy/services/pls-anchor) —
+// AGIC creates and owns that listener, so AGIC's reconcile keeps it alive
+// forever and the bicep read-back picks it up unchanged.
 // ---------------------------------------------------------------------------
 var effectiveFrontendPorts = appGwExists ? existingAppGwConfig!.outputs.frontendPorts : defaultFrontendPorts
-var effectiveBackendAddressPools = concat(
-  filter(
-    appGwExists ? existingAppGwConfig!.outputs.backendAddressPools : defaultBackendAddressPools,
-    p => p.name != 'psPlsBootstrapPool'
-  ),
-  [psPlsBootstrapPool]
-)
-var effectiveBackendHttpSettingsCollection = concat(
-  filter(
-    appGwExists ? existingAppGwConfig!.outputs.backendHttpSettingsCollection : defaultBackendHttpSettingsCollection,
-    s => s.name != 'psPlsBootstrapSettings'
-  ),
-  [psPlsBootstrapSettings]
-)
-var effectiveHttpListeners = concat(
-  filter(
-    appGwExists ? existingAppGwConfig!.outputs.httpListeners : defaultHttpListeners,
-    l => l.name != 'psPlsBootstrapListener'
-  ),
-  [psPlsBootstrapListener]
-)
-var effectiveRequestRoutingRules = concat(
-  filter(
-    appGwExists ? existingAppGwConfig!.outputs.requestRoutingRules : defaultRequestRoutingRules,
-    r => r.name != 'psPlsBootstrapRule'
-  ),
-  [psPlsBootstrapRule]
-)
+var effectiveBackendAddressPools = appGwExists ? existingAppGwConfig!.outputs.backendAddressPools : defaultBackendAddressPools
+var effectiveBackendHttpSettingsCollection = appGwExists ? existingAppGwConfig!.outputs.backendHttpSettingsCollection : defaultBackendHttpSettingsCollection
+var effectiveHttpListeners = appGwExists ? existingAppGwConfig!.outputs.httpListeners : defaultHttpListeners
+var effectiveRequestRoutingRules = appGwExists ? existingAppGwConfig!.outputs.requestRoutingRules : defaultRequestRoutingRules
 var effectiveSslCertificates = appGwExists ? existingAppGwConfig!.outputs.sslCertificates : []
 var effectiveProbes = appGwExists ? existingAppGwConfig!.outputs.probes : []
 var effectiveUrlPathMaps = appGwExists ? existingAppGwConfig!.outputs.urlPathMaps : []

--- a/deploy/services/base-infra/bicep/approver-rg-reader-rbac.bicep
+++ b/deploy/services/base-infra/bicep/approver-rg-reader-rbac.bicep
@@ -6,7 +6,7 @@
 //   1. Reader on the parent RG — so `check-appgw-exists.bicep` can call
 //      `az network application-gateway show` BEFORE the AppGw exists (first
 //      deploy) and distinguish "ResourceNotFound" from "Forbidden".
-//      Tighter than fleet-manager's pattern (which grants Subscription Owner).
+//      Tighter than the reference deployment's pattern (which grants Subscription Owner).
 //
 //   2. Contributor on the Application Gateway — so per-service deployments
 //      can push KV-referenced TLS certs onto the AppGw via

--- a/deploy/services/base-infra/bicep/check-appgw-exists.bicep
+++ b/deploy/services/base-infra/bicep/check-appgw-exists.bicep
@@ -6,7 +6,7 @@
 // `application-gateway.bicep` to drive the AGIC config-preservation
 // ternary (defaults on first deploy, existing values on subsequent deploys).
 //
-// Mirrors postgresql-fleet-manager `check-appgw-exists.bicep`. We use the
+// Mirrors an internal reference deployment. We use the
 // shared `approverIdentity` UAMI (already present in BaseInfra) granted
 // Reader on the RG by `approver-rg-reader-rbac.bicep`.
 // ==============================================================================

--- a/deploy/services/base-infra/bicep/keyvault.bicep
+++ b/deploy/services/base-infra/bicep/keyvault.bicep
@@ -2,7 +2,7 @@
 // PilotSwarm BaseInfra — Azure Key Vault.
 //
 // Stores the 14 worker + 10 portal secrets populated out-of-band by
-// `scripts/deploy-aks.sh` (or by the EV2 shell extension in production).
+// `scripts/deploy-aks.sh` (or by the a separate enterprise orchestration step in production).
 // The CSI SPC UAMI is granted `Key Vault Secrets User` so the AKV CSI
 // provider addon can project those secrets into pods.
 // ==============================================================================
@@ -22,7 +22,7 @@ param csiPrincipalId string
 @description('Optional principal ID of the App Gateway UAMI. When set, granted Key Vault Secrets User so the AppGw control plane can pull TLS certs (KV-referenced sslCertificates).')
 param appGwPrincipalId string = ''
 
-@description('Optional principal ID for the human/local-deploy identity that should receive Key Vault Secrets Officer on this vault. When empty (the EV2 production path), no extra role assignment is created. Local `npm run deploy` populates this with the signed-in AAD user so the new `seed-secrets` step can `az keyvault secret set` without a separate manual role grant.')
+@description('Optional principal ID for the human/local-deploy identity that should receive Key Vault Secrets Officer on this vault. When empty (the enterprise production path), no extra role assignment is created. Local `npm run deploy` populates this with the signed-in AAD user so the new `seed-secrets` step can `az keyvault secret set` without a separate manual role grant.')
 param localDeploymentPrincipalId string = ''
 
 @description('Principal type for localDeploymentPrincipalId. Defaults to User; set to ServicePrincipal or Group to match the principal kind.')
@@ -84,7 +84,7 @@ resource assignKvSecretsUserToAppGw 'Microsoft.Authorization/roleAssignments@202
 }
 
 // Optional Key Vault Secrets Officer on the vault for the local-deploy
-// principal. Skipped when localDeploymentPrincipalId is empty (the EV2
+// principal. Skipped when localDeploymentPrincipalId is empty (the enterprise path
 // production path). When set, this gives the running user data-plane
 // write access to the vault at creation time so the new `seed-secrets`
 // step in deploy.mjs can populate the human-only secrets (github-token,

--- a/deploy/services/base-infra/bicep/keyvault.bicep
+++ b/deploy/services/base-infra/bicep/keyvault.bicep
@@ -2,7 +2,7 @@
 // PilotSwarm BaseInfra — Azure Key Vault.
 //
 // Stores the 14 worker + 10 portal secrets populated out-of-band by
-// `scripts/deploy-aks.sh` (or by the a separate enterprise orchestration step in production).
+// `scripts/deploy-aks.sh` (or by a separate enterprise orchestration step in production).
 // The CSI SPC UAMI is granted `Key Vault Secrets User` so the AKV CSI
 // provider addon can project those secrets into pods.
 // ==============================================================================

--- a/deploy/services/base-infra/bicep/kv-cert-officer-rbac.bicep
+++ b/deploy/services/base-infra/bicep/kv-cert-officer-rbac.bicep
@@ -7,7 +7,7 @@
 // Vault. We grant the approver UAMI (already used for AppGW PE approval)
 // the built-in `Key Vault Certificates Officer` role on the AKV — a single
 // dedicated identity per BaseInfra keeps role-grant churn low and matches
-// the postgresql-fleet-manager `infraDeployManagedIdName` pattern.
+// the an internal reference deployment pattern.
 //
 // Lives in BaseInfra (not Portal) because the AKV is created here and the
 // role assignment must exist before Portal's deployment script runs.

--- a/deploy/services/base-infra/bicep/kv-cert-officer-rbac.bicep
+++ b/deploy/services/base-infra/bicep/kv-cert-officer-rbac.bicep
@@ -7,7 +7,7 @@
 // Vault. We grant the approver UAMI (already used for AppGW PE approval)
 // the built-in `Key Vault Certificates Officer` role on the AKV — a single
 // dedicated identity per BaseInfra keeps role-grant churn low and matches
-// the an internal reference deployment pattern.
+// an internal reference deployment pattern.
 //
 // Lives in BaseInfra (not Portal) because the AKV is created here and the
 // role assignment must exist before Portal's deployment script runs.

--- a/deploy/services/base-infra/bicep/main.bicep
+++ b/deploy/services/base-infra/bicep/main.bicep
@@ -97,17 +97,29 @@ param foundryDeployments array = []
 
 var location = toLower(region)
 
-// Names that must be globally unique and alphanumeric-only use
-// `uniqueString(resourceGroup().id)` as a suffix to keep them short and stable
-// per-RG.
-var uniqueSuffix = substring(uniqueString(resourceGroup().id), 0, 6)
+// Resource naming conventions.
+//
+// All resources are named deterministically from `resourceNamePrefix`, which
+// is expected to encode whatever uniqueness the caller needs (e.g.
+// `<env><regionShortName><stamp>`, like `pilotswarmdevwus31`). The caller is
+// responsible for ensuring the prefix is unique within its scope — e.g. each
+// (env, region, stamp) owns its own subscription/resource-group — so no
+// random hashes are needed to disambiguate names. This lets external tooling
+// (e.g. higher-level deployment orchestrators that wrap this module) compose
+// resource names by convention without runtime lookups against the
+// deployment outputs.
+//
+// `alphaPrefix` strips dashes/underscores to satisfy the alphanumeric naming
+// constraints of ACR / Storage / Key Vault. When the caller already supplies a
+// dashless `resourceNamePrefix`, this is a no-op and `alphaPrefix ==
+// resourceNamePrefix`.
 var alphaPrefix = toLower(replace(replace(resourceNamePrefix, '-', ''), '_', ''))
 
 var aksClusterName = '${resourceNamePrefix}-aks'
-var acrName = '${alphaPrefix}acr${uniqueSuffix}'
-var storageAccountName = '${alphaPrefix}sa${uniqueSuffix}'
-var postgresServerName = '${resourceNamePrefix}-pg-${uniqueSuffix}'
-var keyVaultName = '${alphaPrefix}kv${uniqueSuffix}'
+var acrName = '${alphaPrefix}acr'
+var storageAccountName = '${alphaPrefix}sa'
+var postgresServerName = '${resourceNamePrefix}-pg'
+var keyVaultName = '${alphaPrefix}kv'
 var applicationGatewayName = '${resourceNamePrefix}-appgw'
 var logAnalyticsName = '${resourceNamePrefix}-log'
 var foundryAccountName = '${resourceNamePrefix}-aif'

--- a/deploy/services/base-infra/bicep/main.bicep
+++ b/deploy/services/base-infra/bicep/main.bicep
@@ -3,7 +3,7 @@
 //
 // Composes every per-region resource (AKS, ACR, Storage, PG Flex, AKV, UAMIs,
 // VNet, AppGW with PL config, Flux configs for worker + portal) inside a
-// single resource group. Deployed per region under EV2; the fleet-wide AFD
+// single resource group. Deployed per region under the enterprise path; the fleet-wide AFD
 // profile lives in GlobalInfra and is referenced by name/RG only (Phase 4
 // wires AFD origin + route to the AppGW private frontend).
 // ==============================================================================
@@ -26,7 +26,7 @@ param frontDoorProfileName string
 @description('Resource group that holds the fleet-wide Front Door profile.')
 param frontDoorProfileResourceGroup string
 
-@description('Suffix for the TLS certificate domain (e.g. "pilotswarm.contoso.net"). Consumed by Phase 4; surfaced here as an output so EV2 can thread it through.')
+@description('Suffix for the TLS certificate domain (e.g. "pilotswarm.contoso.net"). Consumed by Phase 4; surfaced here as an output so the enterprise path can thread it through.')
 param sslCertificateDomainSuffix string
 
 @description('ACR SKU (Basic/Standard/Premium). Dev uses Basic; prod uses Premium.')
@@ -58,14 +58,14 @@ param dTime string = utcNow()
 @maxValue(730)
 param logAnalyticsRetentionDays int = 30
 
-@description('Edge topology mode. afd = Front Door + Private Link to AppGw private FE (default; current EV2 + OSS public path). private = no AppGw, no AGIC, no AFD; AKS web-app-routing addon (NGINX) on an internal LoadBalancer instead. Caller is responsible for arranging in-VNet / VPN / Bastion access and DNS resolution (Portal bicep provisions a Private DNS Zone for this).')
+@description('Edge topology mode. afd = Front Door + Private Link to AppGw private FE (default; current enterprise + OSS public path). private = no AppGw, no AGIC, no AFD; AKS web-app-routing addon (NGINX) on an internal LoadBalancer instead. Caller is responsible for arranging in-VNet / VPN / Bastion access and DNS resolution (Portal bicep provisions a Private DNS Zone for this).')
 @allowed([
   'afd'
   'private'
 ])
 param edgeMode string = 'afd'
 
-@description('Optional principal ID (AAD object ID) for the local-deploy identity to receive Storage Blob Data Contributor on the deployment storage account. Defaults to empty for the EV2 production path. Local `npm run deploy` populates this with the signed-in AAD user.')
+@description('Optional principal ID (AAD object ID) for the local-deploy identity to receive Storage Blob Data Contributor on the deployment storage account. Defaults to empty for the enterprise production path. Local `npm run deploy` populates this with the signed-in AAD user.')
 param localDeploymentPrincipalId string = ''
 
 @description('Principal type for localDeploymentPrincipalId.')
@@ -431,7 +431,7 @@ module AppGwPeApprovalRbac './appgw-pe-approval-rbac.bicep' = if (edgeMode == 'a
 // AGIC addon RBAC. The AGIC addon creates its own UAMI in the AKS node RG;
 // that identity (NOT the AKS control-plane UAMI) is what the AGIC pod uses,
 // so it needs explicit role grants on the AppGw + AppGw subnet + AppGw UAMI.
-// Mirrors postgresql-fleet-manager `agic-appgw-rbac` + `agic-vnet-rbac`.
+// Mirrors reference deployment patterns: `agic-vnet-rbac`.
 // Skipped in private mode — AGIC addon is not enabled (web-app-routing is).
 module AgicRbac './agic-rbac.bicep' = if (edgeMode == 'afd') {
   name: '${resourceNamePrefix}-agic-rbac-${dTime}'
@@ -449,7 +449,7 @@ module AgicRbac './agic-rbac.bicep' = if (edgeMode == 'afd') {
 // Same approver UAMI also runs the AKV cert-creation deployment script
 // (Portal/akv-ssl-certificate.bicep) so it needs Key Vault Certificates
 // Officer on the BaseInfra AKV. Reusing one deployment-script identity
-// keeps role-grant churn low and matches the postgresql-fleet-manager
+// keeps role-grant churn low and matches the reference deployment
 // `infraDeployManagedIdName` pattern.
 module KvCertOfficerRbac './kv-cert-officer-rbac.bicep' = {
   name: '${resourceNamePrefix}-kv-certofficer-rbac-${dTime}'
@@ -466,7 +466,7 @@ module KvCertOfficerRbac './kv-cert-officer-rbac.bicep' = {
 // Per-deployable Flux configurations (worker, portal) are now owned by each
 // service's own bicep (deploy/services/worker/bicep/main.bicep,
 // deploy/services/portal/bicep/main.bicep) — matching the
-// postgresql-fleet-manager playgroundservice pattern. BaseInfra installs the
+// reference deployment pattern. BaseInfra installs the
 // `microsoft.flux` extension via aks.bicep but does not configure any
 // per-service `fluxConfigurations` resources.
 //
@@ -474,7 +474,7 @@ module KvCertOfficerRbac './kv-cert-officer-rbac.bicep' = {
 // the Worker and Portal bicep main.bicep files.
 
 // ==============================================================================
-// Outputs (consumed by Phase 4 / EV2 / deploy scripts).
+// Outputs (consumed by Phase 4 / enterprise / OSS deploy scripts).
 // ==============================================================================
 
 output applicationGatewayName string = edgeMode == 'afd' ? AppGateway!.outputs.applicationGatewayName : ''
@@ -509,7 +509,7 @@ output approverIdentityResourceId string = Uami.outputs.approverIdentityResource
 // the Private DNS Zone vnet link (`aksVnetId` param). Always emitted.
 output aksVnetId string = Vnet.outputs.vnetId
 
-// Edge topology mode — echoed back so the orchestrator (deploy.mjs / EV2)
+// Edge topology mode — echoed back so the orchestrator (deploy.mjs / the enterprise path)
 // can fan it into per-service params + skip AFD origin wiring in private.
 output edgeMode string = edgeMode
 

--- a/deploy/services/base-infra/bicep/main.bicep
+++ b/deploy/services/base-infra/bicep/main.bicep
@@ -100,14 +100,25 @@ var location = toLower(region)
 // Resource naming conventions.
 //
 // All resources are named deterministically from `resourceNamePrefix`, which
-// is expected to encode whatever uniqueness the caller needs (e.g.
-// `<env><regionShortName><stamp>`, like `pilotswarmdevwus31`). The caller is
-// responsible for ensuring the prefix is unique within its scope — e.g. each
-// (env, region, stamp) owns its own subscription/resource-group — so no
-// random hashes are needed to disambiguate names. This lets external tooling
-// (e.g. higher-level deployment orchestrators that wrap this module) compose
-// resource names by convention without runtime lookups against the
-// deployment outputs.
+// the caller is expected to encode with whatever uniqueness their scope needs
+// (e.g. `<env><regionShortName><stamp>`, like `pilotswarmdevwus31`). Several
+// of the resources below — ACR, Storage Account, Key Vault, and the Postgres
+// server's public DNS name — live in **globally unique** Azure namespaces, so
+// the caller is responsible for choosing a `resourceNamePrefix` that does not
+// collide with any other tenant's resources of the same type. The `npm run
+// deploy:new-env` scaffolder enforces this in practice by deriving prefixes
+// from a per-developer env name (`ps<envname>`), and higher-level orchestrators
+// compose `<env><regionShort><stamp>` which is unique by construction. No
+// random hashes are added here so that external tooling (e.g. higher-level
+// deployment orchestrators that wrap this module) can compose resource names
+// by convention without runtime lookups against the deployment outputs.
+//
+// Length / charset constraints to keep in mind when picking the prefix:
+//   * Storage Account, Key Vault: 3–24 chars, lowercase alphanumeric only
+//     (the `alphaPrefix` strip below handles dashes/underscores; the length
+//     budget is split between prefix + the `sa`/`kv` suffix below).
+//   * ACR: 5–50 chars, lowercase alphanumeric only.
+//   * Postgres flexible-server: 3–63 chars, lowercase alphanumeric and dashes.
 //
 // `alphaPrefix` strips dashes/underscores to satisfy the alphanumeric naming
 // constraints of ACR / Storage / Key Vault. When the caller already supplies a

--- a/deploy/services/base-infra/bicep/postgres.bicep
+++ b/deploy/services/base-infra/bicep/postgres.bicep
@@ -20,15 +20,15 @@ param databaseName string = 'pilotswarm'
 param administratorLogin string = 'pilotswarm'
 
 // TODO: Replace with Entra (AAD) authentication + workload identity. Until
-// then we hardcode a deterministic placeholder password so EV2 deployments
+// then we hardcode a deterministic placeholder password so enterprise deployments
 // don't need a secret-store dependency. The PG endpoint is reachable only
 // from AKS pods inside the per-region VNet, and the worker reads this
 // password from Key Vault via the AKV CSI Secrets Store provider — the same
 // value must be seeded into KV under `postgres-admin-password` (handled by
-// scripts/deploy-aks.sh today and by a follow-up Ev2 step in production).
+// scripts/deploy-aks.sh today and by a follow-up enterprise step in production).
 //
 // DO NOT use this password for anything reachable from outside the VNet.
-var administratorPassword = 'PilotSwarmEv2_BootstrapOnly!9876'
+var administratorPassword = 'PilotSwarmDev_BootstrapOnly!9876'
 
 @description('Flex Server SKU name.')
 param skuName string = 'Standard_D2ads_v5'

--- a/deploy/services/base-infra/bicep/storage.bicep
+++ b/deploy/services/base-infra/bicep/storage.bicep
@@ -7,7 +7,7 @@
 //
 // Per-deployable manifest containers (worker-manifests, portal-manifests) are
 // owned by each service's own bicep (deploy/services/worker/bicep/main.bicep,
-// deploy/services/portal/bicep/main.bicep) — matching the postgresql-fleet-manager
+// deploy/services/portal/bicep/main.bicep) — matching the reference deployment
 // playgroundservice pattern where each service provisions its own Flux source.
 //
 // The AKS kubelet UAMI is granted Storage Blob Data Reader on the **account**
@@ -36,7 +36,7 @@ param aksKubeletPrincipalId string
 @description('Principal ID of the workload-identity UAMI that the worker / portal pods federate to (CSI SPC UAMI). Granted Storage Blob Data Contributor on this account so the worker can read+write session snapshots when running with PILOTSWARM_USE_MANAGED_IDENTITY=1. Optional for back-compat with stamps that have not been re-deployed since the role assignment was added.')
 param workerWorkloadPrincipalId string = ''
 
-@description('Optional principal ID for the human/local-deploy identity that should receive Storage Blob Data Contributor on this account. When empty (the EV2 production path), no extra role assignment is created. Local `npm run deploy` populates this with the signed-in AAD user so first-time stamps can run `az storage blob upload-batch` without a separate role grant.')
+@description('Optional principal ID for the human/local-deploy identity that should receive Storage Blob Data Contributor on this account. When empty (the enterprise production path), no extra role assignment is created. Local `npm run deploy` populates this with the signed-in AAD user so first-time stamps can run `az storage blob upload-batch` without a separate role grant.')
 param localDeploymentPrincipalId string = ''
 
 @description('Principal type for localDeploymentPrincipalId. Defaults to User; set to ServicePrincipal or Group to match the principal kind.')
@@ -95,7 +95,7 @@ resource assignBlobReaderToKubelet 'Microsoft.Authorization/roleAssignments@2022
 }
 
 // Optional Storage Blob Data Contributor on the account for the local-deploy
-// principal. Skipped when localDeploymentPrincipalId is empty (the EV2
+// principal. Skipped when localDeploymentPrincipalId is empty (the enterprise path
 // production path). When set, this gives the running user data-plane access
 // at storage-account creation time so `az storage blob upload-batch` works
 // on the very first run with no propagation race afterwards.

--- a/deploy/services/base-infra/bicep/uami.bicep
+++ b/deploy/services/base-infra/bicep/uami.bicep
@@ -15,7 +15,7 @@
 //      AppGW) is wired in `appgw-pe-approval-rbac.bicep`. Created in
 //      BaseInfra so the AppGW exists before the role assignment runs.
 //   5. AppGW UAMI — attached to the Application Gateway resource itself.
-//      Mirrors postgresql-fleet-manager's `appGatewayManagedIdName`. Exists
+//      Mirrors reference deployment's `appGatewayManagedIdName`. Exists
 //      primarily so the AGIC addon identity can hold "Managed Identity
 //      Operator" on it (required by AGIC docs to mutate AppGw config that
 //      references a UAMI). Wired in `agic-rbac.bicep`.
@@ -31,7 +31,7 @@ var kubeletIdentityName = '${resourceNamePrefix}-kubelet-mid'
 var csiIdentityName = '${resourceNamePrefix}-csi-mid'
 var approverIdentityName = '${resourceNamePrefix}-pe-approver-mid'
 var aksControlPlaneIdentityName = '${resourceNamePrefix}-aks-cp-mid'
-// Application Gateway UAMI. Mirrors postgresql-fleet-manager's `appGatewayManagedIdName`
+// Application Gateway UAMI. Mirrors reference deployment's `appGatewayManagedIdName`
 // pattern. Required so the AGIC addon can call `assignUserAssignedIdentity` on the
 // AppGw (granted via the Managed Identity Operator role on this UAMI in
 // `agic-rbac.bicep`). System-assigned / addon-only identities don't satisfy

--- a/deploy/services/cert-manager/bicep/main.bicep
+++ b/deploy/services/cert-manager/bicep/main.bicep
@@ -9,7 +9,7 @@
 // the orchestrator deciding the OSS Let's Encrypt path is in use — the
 // orchestrator (deploy/scripts/deploy.mjs) skips the entire `cert-manager`
 // service entry when TLS_SOURCE != letsencrypt, so this module is never
-// invoked on the EV2 / akv path. We don't gate inside the bicep itself
+// invoked on the enterprise / akv path. We don't gate inside the bicep itself
 // because the `services` framework already provides the gate cleanly.
 //
 // Pre-requisites (delivered by BaseInfra):

--- a/deploy/services/common/bicep/akv-certificate-issuer.bicep
+++ b/deploy/services/common/bicep/akv-certificate-issuer.bicep
@@ -1,10 +1,10 @@
 // ==============================================================================
 // AKV certificate issuer registration (idempotent).
 //
-// Adapted from postgresql-fleet-manager `BaseInfra/bicep/akv-certificate-issuer.bicep`.
+// Adapted from an internal reference deployment.
 // Registers a named CA on a Key Vault so subsequent
 // `akv-ssl-certificate.bicep` calls can issue certs against that CA instead
-// of `Self`. Use this when running under EV2 with an internal CA (e.g.
+// of `Self`. Use this when running under the enterprise path with an internal CA (e.g.
 // OneCertV2 / DigiCert). For OSS / dev the default `Self` issuer in
 // `akv-ssl-certificate.bicep` is sufficient and this module is not needed.
 // ==============================================================================

--- a/deploy/services/common/bicep/akv-ssl-certificate.bicep
+++ b/deploy/services/common/bicep/akv-ssl-certificate.bicep
@@ -1,7 +1,7 @@
 // ==============================================================================
 // AKV-managed SSL certificate (idempotent).
 //
-// Adapted from postgresql-fleet-manager `Common/bicep/ssl-certificate.bicep`
+// Adapted from an internal reference deployment
 // (https://github.com/.../src/Deploy/Common/bicep/ssl-certificate.bicep).
 //
 // Behaviour:
@@ -10,7 +10,7 @@
 //   * Otherwise the script generates a default policy, stamps the
 //     `CN=<certificateSubject>`, sets the issuer name (default `Self` for
 //     OSS / dev — overridable to a CA registered via
-//     `akv-certificate-issuer.bicep` for EV2 production), and creates the
+//     `akv-certificate-issuer.bicep` for enterprise / production), and creates the
 //     cert.
 //
 // The created cert is also exposed as a KV *secret* under the same name,
@@ -31,7 +31,7 @@ param certificateName string
 @description('Certificate subject (CN). Typically the portal hostname, e.g. <name>-<region>.<domainSuffix>.')
 param certificateSubject string
 
-@description('AKV issuer name. `Self` issues a self-signed cert (OSS / dev default). Override to a name registered via akv-certificate-issuer.bicep when running with a CA (EV2).')
+@description('AKV issuer name. `Self` issues a self-signed cert (OSS / dev default). Override to a name registered via akv-certificate-issuer.bicep when running with a CA (enterprise).')
 param issuerName string = 'Self'
 
 @description('Resource id of the UAMI the deployment script runs as. Must hold Key Vault Certificates Officer on `akvName`.')
@@ -42,7 +42,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
 }
 
 resource certScript 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
-  // Stable name (matches postgresql-fleet-manager pattern). The script
+  // Stable name (matches reference deployment pattern). The script
   // body is itself idempotent — `az keyvault certificate show` early-exits
   // when the cert already exists — so re-running the deployment is a
   // no-op rather than producing a fresh deploymentScript resource each

--- a/deploy/services/common/bicep/akv-ssl-certificate.bicep
+++ b/deploy/services/common/bicep/akv-ssl-certificate.bicep
@@ -1,8 +1,7 @@
 // ==============================================================================
 // AKV-managed SSL certificate (idempotent).
 //
-// Adapted from an internal reference deployment
-// (https://github.com/.../src/Deploy/Common/bicep/ssl-certificate.bicep).
+// Adapted from an internal reference deployment.
 //
 // Behaviour:
 //   * If the cert already exists in Key Vault, the script is a no-op (so the

--- a/deploy/services/common/bicep/appgw-add-ssl-certificate.bicep
+++ b/deploy/services/common/bicep/appgw-add-ssl-certificate.bicep
@@ -3,7 +3,7 @@
 // an Azure Key Vault secret reference.
 //
 // Used when TLS terminates at the AppGw (instead of inside the Pod). Adapted
-// verbatim from postgresql-fleet-manager `Common/bicep/appgw-add-ssl-certificate.bicep`.
+// verbatim from an internal reference deployment.
 //
 // Implemented as a deployment script (not a Bicep `sslCertificates` array
 // entry) because:

--- a/deploy/services/common/bicep/appgw-add-trusted-root-cert.bicep
+++ b/deploy/services/common/bicep/appgw-add-trusted-root-cert.bicep
@@ -16,7 +16,7 @@
 //   annotation. AppGw then trusts the same self-signed cert when the pod
 //   presents it.
 //
-//   In EV2 production the cert is CA-issued (Microsoft IT CA) so the chain
+//   In enterprise / production the cert is CA-issued (Microsoft IT CA) so the chain
 //   validates out of the box and this module is a deliberate no-op
 //   (cert presence is detected and the script exits early). The module is
 //   still wired in because re-running it is idempotent.

--- a/deploy/services/common/bicep/log-analytics.bicep
+++ b/deploy/services/common/bicep/log-analytics.bicep
@@ -9,7 +9,7 @@
 //     Front Door WAF policy diagnostic logs). Kept separate from any single
 //     stamp so AFD telemetry isn't coupled to a specific region's lifecycle.
 //
-// Pattern adopted from postgresql-fleet-manager
+// Pattern adopted from reference deployment
 // (src/Deploy/BaseInfra/bicep/application-insights.bicep), simplified: no
 // AppInsights component yet — PilotSwarm Node services don't emit
 // AppInsights telemetry today. Workspace alone is sufficient for the

--- a/deploy/services/deploy-manifest.json
+++ b/deploy/services/deploy-manifest.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "_comment": "Root manifest for the OSS Node deploy orchestrator (deploy/scripts/). Distinct from the EV2 services.json that sits alongside this file (which will be ported to a parent repo). Each entry in `services` plus each name in `infraOrder` MUST have a matching deploy/services/<name>/deploy.json file.",
 
-  "infraOrder": ["global-infra", "base-infra", "cert-manager", "cert-manager-issuers"],
+  "infraOrder": ["global-infra", "base-infra", "pls-anchor", "cert-manager", "cert-manager-issuers"],
   "services":   ["worker", "portal"],
 
   "regionShort": {

--- a/deploy/services/global-infra/bicep/frontdoor-profile.bicep
+++ b/deploy/services/global-infra/bicep/frontdoor-profile.bicep
@@ -1,9 +1,9 @@
 // ==============================================================================
 // Azure Front Door Premium profile + endpoint + security policy.
 //
-// Adapted from postgresql-fleet-manager/src/Deploy/GlobalInfra/bicep/
+// Adapted from an internal reference deployment
 // frontdoor-profile.bicep. Per-region BaseInfra rollouts add custom domains
-// and Private Link origins to the endpoint created here via EV2 shell
+// and Private Link origins to the endpoint created here via the enterprise orchestration step
 // extensions at rollout time.
 // ==============================================================================
 

--- a/deploy/services/global-infra/bicep/frontdoor-waf-policy.bicep
+++ b/deploy/services/global-infra/bicep/frontdoor-waf-policy.bicep
@@ -1,7 +1,7 @@
 // ==============================================================================
 // WAF policy for Azure Front Door Premium.
 //
-// Adapted from postgresql-fleet-manager/src/Deploy/GlobalInfra/bicep/
+// Adapted from an internal reference deployment
 // frontdoor-waf-policy.bicep. The `wafMode` is parameterized so a single
 // template backs both environments:
 //   dev  -> Detection  (log only; never block during bring-up)
@@ -24,7 +24,7 @@ param location string = 'global'
 @description('Custom WAF rules merged into properties.customRules.rules. Defaults to []. Populate via --parameters customRules=@<file.json> (e.g. corpnet allow-list rules) without checking values into source.')
 param customRules array = []
 
-@description('Managed rule sets applied to every request. Defaults to Microsoft DefaultRuleSet 2.1 + BotManager 1.1, matching the fleet-manager reference. The DefaultRuleSet exclusions cover request attributes that carry opaque structured payloads (bearer JWTs, MSAL state cookies, portal UI-state cookies) whose base64 / JSON content routinely matches OWASP SQLi/XSS rules and produces false-positive blocks. Token validation (issuer / audience / signature) happens at the portal via JWKS — there is no security benefit to scanning these.')
+@description('Managed rule sets applied to every request. Defaults to Microsoft DefaultRuleSet 2.1 + BotManager 1.1, matching the reference deployment. The DefaultRuleSet exclusions cover request attributes that carry opaque structured payloads (bearer JWTs, MSAL state cookies, portal UI-state cookies) whose base64 / JSON content routinely matches OWASP SQLi/XSS rules and produces false-positive blocks. Token validation (issuer / audience / signature) happens at the portal via JWKS — there is no security benefit to scanning these.')
 param managedRuleSets array = [
   {
     ruleSetType: 'Microsoft_DefaultRuleSet'

--- a/deploy/services/global-infra/bicep/main.bicep
+++ b/deploy/services/global-infra/bicep/main.bicep
@@ -3,7 +3,7 @@ targetScope = 'subscription'
 // ==============================================================================
 // PilotSwarm GlobalInfra — fleet-wide Azure Front Door Premium + WAF.
 //
-// Adapted from postgresql-fleet-manager/src/Deploy/GlobalInfra/bicep/main.bicep.
+// Adapted from an internal reference deployment
 // Creates a single global AFD Premium profile shared by every region, with a
 // WAF policy whose mode is environment-parameterized (Detection for dev so
 // false positives never block traffic during bring-up; Prevention for prod).
@@ -24,7 +24,7 @@ param resourceGroupName string
 @description('Naming prefix. Applied to every resource so fleet-wide resources stay correlated in Azure Portal searches.')
 param resourcePrefix string = 'pilotswarm'
 
-@description('WAF mode. Detection logs only; Prevention blocks. Set per-environment via EV2 Configuration.')
+@description('WAF mode. Detection logs only; Prevention blocks. Set per-environment via enterprise Configuration.')
 @allowed([
   'Detection'
   'Prevention'
@@ -111,7 +111,7 @@ module frontDoorProfile './frontdoor-profile.bicep' = {
 }
 
 // ==============================================================================
-// Outputs (consumed by BaseInfra per-region rollouts and by EV2 shell
+// Outputs (consumed by BaseInfra per-region rollouts and by the enterprise orchestration step
 // extensions that bind per-region origins to this global endpoint).
 // ==============================================================================
 

--- a/deploy/services/pls-anchor/bicep/main.bicep
+++ b/deploy/services/pls-anchor/bicep/main.bicep
@@ -29,11 +29,9 @@
 //     referencing it (application-gateway.bicep).
 //   - AGIC add-on enabled on AKS (aks.bicep).
 //
-// Reference: postgresql-fleet-manager
-// `src/Deploy/BaseInfra/geneva-manifests/base/pls-anchor-{service,ingress}.yaml`
-// (FM bundles the anchor inside the geneva manifests kustomization; we package
-// it as its own service for clean separation since PilotSwarm has no Geneva
-// equivalent).
+// Adapted from an internal reference deployment, which bundles the anchor
+// inside a larger observability-manifests kustomization. PilotSwarm packages
+// it as its own infra service for clean separation.
 // ==============================================================================
 
 targetScope = 'resourceGroup'

--- a/deploy/services/pls-anchor/bicep/main.bicep
+++ b/deploy/services/pls-anchor/bicep/main.bicep
@@ -1,0 +1,79 @@
+// ==============================================================================
+// PilotSwarm pls-anchor — manifest container + Flux configuration.
+// ==============================================================================
+// Scope: resource group (BaseInfra RG — same RG that owns the storage account
+// and AKS cluster).
+//
+// Ships the tiny `pls-anchor` namespace + empty Service + private-FE Ingress
+// (deploy/gitops/pls-anchor/base/) into the BaseInfra cluster via Flux. The
+// Ingress carries the `appgw.ingress.kubernetes.io/use-private-ip: "true"`
+// annotation which tells AGIC to create — and own — an httpListener on the
+// AppGw private frontend IP. That listener is what causes Azure to materialise
+// the hidden Private Link Service backing the AppGw `privateLinkConfiguration`,
+// and because AGIC owns it, AGIC's reconcile keeps it alive forever. Front
+// Door's Private Endpoint then has a stable PLS to attach to.
+//
+// Conditional on the orchestrator deciding the AFD edge mode is in use — the
+// orchestrator (deploy/scripts/deploy.mjs) skips the entire `pls-anchor` service
+// entry when EDGE_MODE != afd (no Front Door, no PE, nothing to anchor). We
+// don't gate inside the bicep itself because the `services` framework already
+// provides the gate cleanly.
+//
+// Pre-requisites (delivered by BaseInfra):
+//   - Storage account exists.
+//   - AKS cluster exists with the `microsoft.flux` extension installed and
+//     `useKubeletIdentity: 'true'`.
+//   - The AKS kubelet UAMI has `Storage Blob Data Reader` on the storage
+//     account (account-scope grant in storage.bicep).
+//   - AppGw with `privateLinkConfigurations` + `appGatewayPrivateFrontendIP`
+//     referencing it (application-gateway.bicep).
+//   - AGIC add-on enabled on AKS (aks.bicep).
+//
+// Reference: postgresql-fleet-manager
+// `src/Deploy/BaseInfra/geneva-manifests/base/pls-anchor-{service,ingress}.yaml`
+// (FM bundles the anchor inside the geneva manifests kustomization; we package
+// it as its own service for clean separation since PilotSwarm has no Geneva
+// equivalent).
+// ==============================================================================
+
+targetScope = 'resourceGroup'
+
+@description('Timestamp for unique deployment names.')
+param dTime string = utcNow()
+
+@description('BaseInfra storage account name (Flux source for pls-anchor-manifests container).')
+param storageAccountName string
+
+@description('BaseInfra AKS cluster name (parent of the Flux extension).')
+param aksClusterName string
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource plsAnchorManifestsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'pls-anchor-manifests'
+  properties: {
+    publicAccess: 'None'
+  }
+}
+
+module PlsAnchorFluxConfig '../../common/bicep/flux-config.bicep' = {
+  name: 'pls-anchor-flux-${dTime}'
+  params: {
+    aksClusterName: aksClusterName
+    configName: 'pls-anchor'
+    blobContainerEndpoint: storageAccount.properties.primaryEndpoints.blob
+    containerName: plsAnchorManifestsContainer.name
+    kustomizationPath: 'overlays/default'
+  }
+}
+
+@description('pls-anchor manifest container name (consumed by the OSS deploy script as DEPLOYMENT_STORAGE_CONTAINER_NAME via FR-022 alias).')
+output manifestsContainerName string = plsAnchorManifestsContainer.name

--- a/deploy/services/pls-anchor/bicep/pls-anchor.params.template.json
+++ b/deploy/services/pls-anchor/bicep/pls-anchor.params.template.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "value": "${DEPLOYMENT_STORAGE_ACCOUNT_NAME}"
+    },
+    "aksClusterName": {
+      "value": "${AKS_CLUSTER_NAME}"
+    }
+  }
+}

--- a/deploy/services/pls-anchor/deploy.json
+++ b/deploy/services/pls-anchor/deploy.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "../deploy.schema.json",
+  "schemaVersion": 1,
+  "_comment": "OSS per-service deploy manifest for pls-anchor. Conditional service: deploy.mjs skips this entry entirely when EDGE_MODE != afd (no AppGw, no hidden PLS to anchor).",
+  "name": "pls-anchor",
+  "kind": "infra",
+  "bicep": {
+    "modules": [
+      { "name": "base-infra",  "scope": "group" },
+      { "name": "pls-anchor",  "scope": "group" }
+    ],
+    "allModeModules": [
+      { "name": "pls-anchor", "scope": "group" }
+    ]
+  },
+  "pipeline": ["bicep", "manifests"]
+}

--- a/deploy/services/portal/bicep/main.bicep
+++ b/deploy/services/portal/bicep/main.bicep
@@ -35,6 +35,9 @@ targetScope = 'resourceGroup'
 @description('Short resource-name root, e.g. pilotswarmprod1. Must match the value used by BaseInfra so the AppGW hostname aligns.')
 param resourceName string
 
+@description('BaseInfra `resourceNamePrefix` value used to look up the CSI Secrets Provider UAMI by convention name. May differ from `resourceName` in OSS direct deploys, where Portal has its own logical name (`<prefix>-<region>-portal`) while BaseInfra resources use a shorter prefix. Downstream callers that wrap this module may pass any prefix shaped per their own environment-region-stamp convention.')
+param baseInfraResourceNamePrefix string
+
 @description('Azure region (lowercased). Used in the certificate subject to disambiguate multi-region deployments.')
 param region string
 
@@ -188,6 +191,20 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing 
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
   parent: storageAccount
   name: 'default'
+}
+
+// CSI Secrets Provider UAMI (created by BaseInfra's `uami.bicep` module). The
+// UAMI is named `${baseInfraResourceNamePrefix}-csi-mid` by convention; we
+// look it up here so its clientId can be exposed as a Portal own-package
+// output. This makes the value reachable by downstream callers (e.g.
+// higher-level deployment orchestrators that compose this bicep across
+// independent deployment boundaries and can only see each package's own
+// outputs) for Workload Identity federation in the AKS app deploy step.
+// When OSS deploys directly, `deploy-bicep.mjs` already wires
+// `csiIdentityClientId` into manifest substitution via the
+// `WORKLOAD_IDENTITY_CLIENT_ID` env alias, so this output is purely additive.
+resource csiUami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: '${baseInfraResourceNamePrefix}-csi-mid'
 }
 
 resource portalManifestsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
@@ -388,3 +405,6 @@ output ApprovedPrivateEndpointCount int = edgeMode == 'afd' ? plApprove.outputs.
 
 @description('Portal manifest container name (consumed by OSS deploy script as DEPLOYMENT_STORAGE_CONTAINER_NAME via FR-022 alias).')
 output manifestsContainerName string = portalManifestsContainer.name
+
+@description('Client ID of the CSI Secrets Provider UAMI (looked up by convention name from this RG). Consumed by the AKS app-deploy step (and by downstream callers that wrap this bicep) to federate Workload Identity.')
+output csiIdentityClientId string = csiUami.properties.clientId

--- a/deploy/services/portal/bicep/main.bicep
+++ b/deploy/services/portal/bicep/main.bicep
@@ -8,7 +8,7 @@
 //
 // This module does NOT provision the portal Kubernetes workload — that is
 // reconciled by FLUX from the portal manifest blob container which IS owned
-// by this bicep (per the postgresql-fleet-manager playgroundservice pattern:
+// by this bicep (per the reference deployment pattern:
 // each service provisions its own Flux source in its own bicep).
 //
 // What this module does:
@@ -22,7 +22,7 @@
 //      in the GlobalInfra RG (via the verbatim shared module).
 //   6. Auto-approves the pending PLS connection on the AppGW side.
 //
-// Surfaces BackendHostName as an output so EV2 scope binding can fan it
+// Surfaces BackendHostName as an output so the enterprise orchestrator's scope binding can fan it
 // into overlay/.env as PORTAL_HOSTNAME (Spec FR-014).
 // ==============================================================================
 
@@ -44,14 +44,14 @@ param region string
 @description('DNS suffix for the portal cert, e.g. pilotswarm.azure.com. Required in EDGE_MODE=afd + TLS_SOURCE=akv (used to derive resourceName.suffix as cert subject + AFD origin host). Ignored when EDGE_MODE=afd + TLS_SOURCE=letsencrypt (cert subject derives from the AppGw cloudapp.azure.com label) or when EDGE_MODE=private (caller supplies portalHostnameOverride).')
 param sslCertificateDomainSuffix string
 
-@description('Edge topology mode. afd = Front Door + Private Link to AppGw private FE (default; covers OSS via the AppGw cloudapp.azure.com DNS label and EV2 via a custom domain). private = AppGw private IP listener only, no AFD; caller must supply portalHostnameOverride and arrange DNS resolution to APP_GATEWAY_PRIVATE_IP.')
+@description('Edge topology mode. afd = Front Door + Private Link to AppGw private FE (default; covers OSS via the AppGw cloudapp.azure.com DNS label and the enterprise path via a custom domain). private = AppGw private IP listener only, no AFD; caller must supply portalHostnameOverride and arrange DNS resolution to APP_GATEWAY_PRIVATE_IP.')
 @allowed([
   'afd'
   'private'
 ])
 param edgeMode string = 'afd'
 
-@description('TLS cert source. letsencrypt = cert-manager + LE prod (cert lands in a K8s Secret managed by cert-manager; bicep skips the AKV cert deployment script). akv = AKV-registered issuer + bicep cert script (current EV2 / enterprise path; default preserves EV2 behavior when the param is not supplied). akv-selfsigned = AKV `Self` issuer + bicep cert script (OSS / dev convenience for private mode; produces a self-signed cert in AKV, no CA registration required, NOT trusted by browsers without manual trust).')
+@description('TLS cert source. letsencrypt = cert-manager + LE prod (cert lands in a K8s Secret managed by cert-manager; bicep skips the AKV cert deployment script). akv = AKV-registered issuer + bicep cert script (current enterprise path; default preserves enterprise path behavior when the param is not supplied). akv-selfsigned = AKV `Self` issuer + bicep cert script (OSS / dev convenience for private mode; produces a self-signed cert in AKV, no CA registration required, NOT trusted by browsers without manual trust).')
 @allowed([
   'letsencrypt'
   'akv'
@@ -113,7 +113,7 @@ param certScriptIdentityResourceId string
 @description('Name of the cert in AKV. Must match the SPC objectName/secretName used by the portal TLS volume (deploy/gitops/portal/base/secret-provider-class.yaml). Only consumed when tlsSource is akv.')
 param portalTlsCertName string = 'pilotswarm-portal-tls'
 
-@description('AKV issuer name (registered via akv-certificate-issuer.bicep) for tlsSource=akv. When empty (default), bicep registers and uses OneCertV2-PublicCA (afd) or OneCertV2-PrivateCA (private) per the fleet-manager pattern. Ignored when tlsSource is akv-selfsigned (uses the built-in `Self` issuer) or letsencrypt (cert-manager owns the cert).')
+@description('AKV issuer name (registered via akv-certificate-issuer.bicep) for tlsSource=akv. When empty (default), bicep registers and uses OneCertV2-PublicCA (afd) or OneCertV2-PrivateCA (private) per the reference deployment pattern. Ignored when tlsSource is akv-selfsigned (uses the built-in `Self` issuer) or letsencrypt (cert-manager owns the cert).')
 param portalTlsIssuerName string = ''
 
 // -----------------------------------------------------------------------------
@@ -180,7 +180,7 @@ resource applicationGateway 'Microsoft.Network/applicationGateways@2024-01-01' e
 }
 
 // -----------------------------------------------------------------------------
-// Portal manifest container + Flux source (owned by Portal per fleet-manager
+// Portal manifest container + Flux source (owned by Portal per reference deployment
 // playgroundservice pattern).
 // -----------------------------------------------------------------------------
 
@@ -263,9 +263,9 @@ resource portalPrivateDnsZoneVnetLink 'Microsoft.Network/privateDnsZones/virtual
 // Self issuer) and for tlsSource=letsencrypt (cert-manager owns the cert,
 // AKV is not in the path).
 //
-// Pattern matches postgresql-fleet-manager: afd lands on the public CA,
+// Pattern matches reference deployment: afd lands on the public CA,
 // private lands on the private CA (e.g. AME OneCertV2-PrivateCA registered
-// for the AKV by EV2 / OneCert onboarding).
+// for the AKV by enterprise OneCert onboarding).
 // -----------------------------------------------------------------------------
 module PortalAkvIssuer '../../common/bicep/akv-certificate-issuer.bicep' = if (tlsSource == 'akv') {
   name: 'portal-akv-issuer-${dTime}'
@@ -389,7 +389,7 @@ module plApprove '../../common/bicep/approve-private-endpoint.bicep' = if (edgeM
 // Outputs
 // -----------------------------------------------------------------------------
 
-@description('AFD backend hostname / AppGW listener host / Portal Ingress host. EV2 scope-binds this into overlay/.env as PORTAL_HOSTNAME.')
+@description('AFD backend hostname / AppGW listener host / Portal Ingress host. The enterprise orchestrator scope-binds this into overlay/.env as PORTAL_HOSTNAME.')
 output BackendHostName string = certificateSubject
 
 @description('Computed PLS service id string (audit/diagnostic).')

--- a/deploy/services/portal/bicep/portal.params.template.json
+++ b/deploy/services/portal/bicep/portal.params.template.json
@@ -5,6 +5,9 @@
     "resourceName": {
       "value": "${PORTAL_RESOURCE_NAME}"
     },
+    "baseInfraResourceNamePrefix": {
+      "value": "${RESOURCE_PREFIX}"
+    },
     "region": {
       "value": "${LOCATION}"
     },

--- a/deploy/services/worker/bicep/main.bicep
+++ b/deploy/services/worker/bicep/main.bicep
@@ -6,7 +6,7 @@
 //
 // This module does NOT provision the worker Kubernetes workload — that is
 // reconciled by FLUX from the worker manifest blob container which IS owned
-// by this bicep (per the postgresql-fleet-manager playgroundservice pattern:
+// by this bicep (per the reference deployment pattern:
 // each service provisions its own Flux source in its own bicep).
 //
 // What this module does:

--- a/deploy/services/worker/bicep/main.bicep
+++ b/deploy/services/worker/bicep/main.bicep
@@ -28,6 +28,9 @@ targetScope = 'resourceGroup'
 @description('Timestamp for unique deployment names.')
 param dTime string = utcNow()
 
+@description('BaseInfra `resourceNamePrefix` value used to look up the CSI Secrets Provider UAMI by convention name. Downstream callers that wrap this module may pass any prefix shaped per their own environment-region-stamp convention.')
+param baseInfraResourceNamePrefix string
+
 @description('BaseInfra storage account name (Flux source for worker-manifests container).')
 param storageAccountName string
 
@@ -41,6 +44,16 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' existing 
 resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' existing = {
   parent: storageAccount
   name: 'default'
+}
+
+// CSI Secrets Provider UAMI (created by BaseInfra's `uami.bicep`). Looked up
+// by convention name so its clientId can be exposed as a Worker own-package
+// output. This makes the value reachable by downstream callers (e.g.
+// higher-level deployment orchestrators that compose this bicep across
+// independent deployment boundaries and can only see each package's own
+// outputs) for Workload Identity federation in the AKS app deploy step.
+resource csiUami 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' existing = {
+  name: '${baseInfraResourceNamePrefix}-csi-mid'
 }
 
 resource workerManifestsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
@@ -64,3 +77,6 @@ module WorkerFluxConfig '../../common/bicep/flux-config.bicep' = {
 
 @description('Worker manifest container name (consumed by OSS deploy script as DEPLOYMENT_STORAGE_CONTAINER_NAME via FR-022 alias).')
 output manifestsContainerName string = workerManifestsContainer.name
+
+@description('Client ID of the CSI Secrets Provider UAMI (looked up by convention name from this RG). Consumed by the AKS app-deploy step (and by downstream callers that wrap this bicep) to federate Workload Identity.')
+output csiIdentityClientId string = csiUami.properties.clientId

--- a/deploy/services/worker/bicep/worker.params.template.json
+++ b/deploy/services/worker/bicep/worker.params.template.json
@@ -2,6 +2,9 @@
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
+    "baseInfraResourceNamePrefix": {
+      "value": "${RESOURCE_PREFIX}"
+    },
     "storageAccountName": {
       "value": "${DEPLOYMENT_STORAGE_ACCOUNT_NAME}"
     },

--- a/docs/deploying-to-aks.md
+++ b/docs/deploying-to-aks.md
@@ -11,7 +11,7 @@ This guide walks through deploying PilotSwarm workers to AKS for production mult
 > 2. **GitOps IaC pipeline under `deploy/`** (described below in
 >    [GitOps IaC Path](#gitops-iac-path)). Bicep-managed Azure infra +
 >    Flux-driven cluster manifests, pulled from versioned blob
->    containers. Modeled on the postgresql-fleet-manager reference
+>    containers. Modeled on a known-good internal reference
 >    implementation, simplified for PilotSwarm's single-service Node.js
 >    shape. This path adds Edge Mode (AFD vs Private AppGw) and TLS
 >    Source (AKV vs Let's Encrypt) topology choices.
@@ -41,11 +41,11 @@ combinations are supported; two are blocked:
 | `EDGE_MODE` | `TLS_SOURCE`     | Edge ingress                                  | Cert source                                            | Notes                                          |
 |-------------|------------------|-----------------------------------------------|--------------------------------------------------------|------------------------------------------------|
 | `afd`       | `letsencrypt`    | AFD → AppGw (Private Link) + AGIC             | cert-manager + Let's Encrypt prod (HTTP-01)            | OSS default. Zero CA setup.                    |
-| `afd`       | `akv`            | AFD → AppGw (Private Link) + AGIC             | OneCertV2-PublicCA via AKV (registered automatically)  | EV2 default. BYO public CA.                    |
+| `afd`       | `akv`            | AFD → AppGw (Private Link) + AGIC             | OneCertV2-PublicCA via AKV (registered automatically)  | enterprise default. BYO public CA.                    |
 | `private`   | `akv`            | AKS web-app-routing addon (NGINX) + ILB       | OneCertV2-PrivateCA via AKV (registered automatically) | Enterprise / AME. No AFD, no AppGw, no AGIC.   |
 | `private`   | `akv-selfsigned` | AKS web-app-routing addon (NGINX) + ILB       | AKV `Self` issuer (auto-generated, in-place)           | No CA; private-VNet smoke tests.               |
 
-Default for OSS = `afd` + `letsencrypt`. Default for EV2 =
+Default for OSS = `afd` + `letsencrypt`. Default for the enterprise path =
 `afd` + `akv`.
 
 - **`EDGE_MODE=afd`** — Azure Front Door fronts a regional Application
@@ -120,7 +120,7 @@ these gates.
 `version: 1.20.2` exact (no semver range). To upgrade, edit that field
 in a PR — Flux will not auto-roll. The OCI HelmRepository points at
 `oci://quay.io/jetstack/charts` (official Jetstack registry) for OSS;
-EV2 stays on the AKV path so this chart source is OSS-only.
+the enterprise path stays on the AKV path so this chart source is OSS-only.
 
 ClusterIssuers live in a separate Kustomization
 (`cert-manager-issuers`) so the issuer install retries cleanly while


### PR DESCRIPTION
 ## Summary

 Three coordinated changes to the deploy bicep so resource names are fully deterministic from a single prefix, downstream callers that wrap these modules can reach the
per-region Workload Identity client ID without poking at base-infra outputs they can't see, and the Application Gateway survives AGIC reconciliation cleanly without
losing the hidden Private Link Service that AFD's portal origin depends on.

 Plus a documentation/comment-only sweep across the whole `deploy/` tree to remove references to internal-only deployment systems and an internal reference repo, so OSS
readers don't have to know about systems they can't access in order to read the code.

 ## Why

 The OSS bicep was written so that ACR / Storage / Key Vault / Postgres names mixed `resourceNamePrefix` with a runtime `uniqueSuffix` (a hash of the deployment name).
That works fine for direct OSS deploys via `deploy/scripts/deploy.mjs` because the script reads bicep outputs and threads them into the next step. It does **not** work
for higher-level deployment orchestrators that wrap this bicep across independent deployment boundaries — those compose names by convention up-front and can only see
each package's own outputs, so they can't read a runtime-computed suffix from a sibling package.

 Same problem for the AKS Workload Identity client ID: base-infra emits `csiIdentityClientId`, but the AKS app-deploy step (and any downstream caller of Portal/Worker
bicep) can only reach Portal's / Worker's own outputs. It needs the same value visible from those modules.

 Separately, the Application Gateway path was getting wiped on AGIC reconcile: bicep added a private-frontend HTTP listener so AFD could attach a Private Endpoint to the
 auto-generated Private Link Service, but AGIC (which owns the AppGw config in default mode) reconciled it away on every sync, deleting the hidden PLS and breaking
subsequent portal AFD-origin deploys with `ThirdPartyPrivateLinkServiceProvidedDuringPrivateEndpointCreationDoesNotExistOrIsNotVisible`.

 ## Changes

 ### `base-infra/bicep/main.bicep` — drop `uniqueSuffix`

 - Resource names compose purely from `resourceNamePrefix` / `alphaPrefix`:
   - ACR: `${alphaPrefix}acr`
   - Storage: `${alphaPrefix}sa`
   - Key Vault: `${alphaPrefix}kv`
   - Postgres: `${resourceNamePrefix}-pg` (was `${resourceNamePrefix}-pg-${uniqueSuffix}`)
 - Per-(env, region) uniqueness now comes from the prefix itself plus subscription/resource-group isolation. The caller is responsible for choosing a prefix that's
unique within its scope; that's already true for direct OSS deploys (they pass an env-derived prefix) and for downstream callers (they compose `<env><region><stamp>`).
 - No new params, no new outputs, no resource type changes.

 ### `portal/bicep/main.bicep` and `worker/bicep/main.bicep` — expose `csiIdentityClientId`

 - Add new param `baseInfraResourceNamePrefix` (string). This is distinct from the existing `resourceName` because in OSS direct deploys `resourceName` is the
**Portal-logical** name (`${prefix}-${regionShort}-portal`), not the BaseInfra prefix. Downstream callers will set both equal; OSS sets `baseInfraResourceNamePrefix =
${RESOURCE_PREFIX}`.
 - Add an `existing` lookup of the CSI Secrets Provider UAMI (`${baseInfraResourceNamePrefix}-csi-mid`) and surface its clientId as `output csiIdentityClientId`. The
output name reuses the alias-map entry that already exists in `deploy/scripts/lib/deploy-bicep.mjs` (`csiIdentityClientId → WORKLOAD_IDENTITY_CLIENT_ID`), so OSS direct
deploys are unaffected — Portal/Worker just emit the same value BaseInfra already emits, which is consistent.

 ### Param templates

 - `portal.params.template.json` and `worker.params.template.json`: bind the new `baseInfraResourceNamePrefix` to the existing `${RESOURCE_PREFIX}` env var. No new
env-var contract for OSS users.

 ### New `pls-anchor` infra service — make AppGw private-FE listener AGIC-durable

 The AppGw private-FE listener that materializes the hidden Private Link Service (which AFD attaches its portal-origin Private Endpoint to) was being added by bicep and
immediately reconciled away by AGIC. AGIC owns the AppGw config in default mode and only preserves listeners it derives from a Kubernetes Ingress object.

 This change adopts a well-known reference pattern that lets AGIC own the listener:

 - New top-level infra service `pls-anchor`:
   - `deploy/gitops/pls-anchor/base/`: empty `ClusterIP` Service + Ingress with `appgw.ingress.kubernetes.io/use-private-ip: "true"`, in `pls-anchor-system` namespace.
Flux installs it; AGIC creates a permanent listener on the AppGw private frontend from the Ingress and keeps it alive forever, so the hidden PLS persists across
reconciles.
   - `deploy/services/pls-anchor/bicep/main.bicep`: creates a `pls-anchor-manifests` blob container in the BaseInfra storage account and a FluxConfig pointing at it.
Mirrors the existing `cert-manager` infra-service shape.
   - `deploy/services/pls-anchor/deploy.json`: `kind: infra`, pipeline `[bicep, manifests]`.
 - `deploy/services/deploy-manifest.json`: `pls-anchor` slots into `infraOrder` between `base-infra` and `cert-manager`, so the anchor is in place before any service
tries to attach a PE to the PLS.
 - `deploy/scripts/deploy.mjs`: skip `pls-anchor` when `EDGE_MODE != afd` (it's only relevant when AFD is fronting the AppGw via Private Link).
 - `deploy/services/base-infra/bicep/application-gateway.bicep`:
   - **Drop** the previous `psPlsBootstrap{Pool,Settings,Listener,Rule}` block and the concat-with-filter machinery for
`effective{BackendAddressPools,BackendHttpSettingsCollection,HttpListeners,RequestRoutingRules}`. That pattern was the AGIC fight — bicep kept re-adding the listener and
 AGIC kept removing it.
   - **Replace** with the simpler reference pattern: straight ternaries (`appGwExists ? existing : defaults`) so on re-deploys the bicep just echoes back AGIC's current
state unchanged.
   - **Seed** both the public and private FE listener + routing rule in the static defaults so a clean first deploy materializes the PLS immediately; AGIC then takes
ownership via the anchor Ingress.

 Net effect: no AGIC fight, PLS stays alive across reconciles, AFD origin PE creation succeeds on every redeploy.

 ### Comment / doc sanitization (43 files)

 A separate commit on this branch is documentation/comment-only across the entire `deploy/` tree plus `docs/deploying-to-aks.md`:

 - Replaces references to internal-only deployment infrastructure (by name) and an internal reference repo (by name) with generic phrasing like "the enterprise path" and
 "an internal reference deployment".
 - Removes pointers to internal-only files that don't exist in this OSS repo.

 The only behavioral change in that sweep is renaming the deterministic Postgres bootstrap-admin password literal:

 - `PilotSwarmEv2_BootstrapOnly!9876` → `PilotSwarmDev_BootstrapOnly!9876`

 It moves together in all three places it appears (`postgres.bicep`, `compose-env.mjs`, `compose-env.test.mjs`) so the OSS path and tests stay self-consistent. The
password is a deterministic placeholder used only on a fresh stamp until the operator seeds the real value into Key Vault, and the PG endpoint is reachable only from
inside the per-region VNet.

 ## Backward compatibility

 - **OSS direct deploys (`npm run deploy`)**: unchanged behavior. The new Portal/Worker param has a sensible default mapping in the param templates, the new outputs
reuse the existing alias-map entry, and resource names (ACR/SA/KV) only change in that they no longer carry the random suffix — but the deploy script consumes them by
output name, not by spelling, so `deploy.mjs` keeps working.
 - **`pls-anchor`**: new opt-in infra service that only runs when `EDGE_MODE=afd`. Other edge modes are untouched. Existing AFD environments where AGIC has already wiped
 the bootstrap listener need a one-time recovery (re-create the private-FE listener via `az network application-gateway http-listener create`, then deploy `pls-anchor`);
 after that, AGIC keeps the listener alive via the Ingress.
 - **Postgres**: the FQDN changes from `<prefix>-pg-<suffix>.postgres.database.azure.com` to `<prefix>-pg.postgres.database.azure.com`. Any pre-existing stamps that ran
the old bicep will see Postgres as a delete-and-recreate on next deploy. None exist in production OSS today.

 ## Validation

 - `az bicep build` clean on every top-level module (`base-infra`, `portal`, `worker`, `global-infra`, `cert-manager`, `pls-anchor`).
 - `node --test deploy/scripts/test/*.test.mjs` → 125 / 125 pass.
 - Final repo-wide grep confirms zero remaining references to internal-only system names or the internal reference repo (excluding genuine product names like
`StorageV2`, `MSAL`).

 ## Commits

 1. `base-infra: drop uniqueSuffix + portal/worker: expose csiIdentityClientId via existing-UAMI lookup`
 2. `docs+comments: generalize references to internal-only deployment systems`
 3. `base-infra+pls-anchor: adopt FM PLS-anchor pattern for AGIC durability`