### PR TITLE
feat(optimization): add storage foundations for DB read bounds

### DIFF
--- a/packages/sdk/src/cms-migrations.ts
+++ b/packages/sdk/src/cms-migrations.ts
@@ -75,6 +75,16 @@ export function CMS_MIGRATIONS(schema: string): MigrationEntry[] {
             name: "session_reasoning_effort_read_views",
             sql: migration_0012_session_reasoning_effort_read_views(schema),
         },
+        {
+            version: "0013",
+            name: "bounded_session_reads_and_emitters",
+            sql: migration_0013_bounded_session_reads_and_emitters(schema),
+        },
+        {
+            version: "0014",
+            name: "turn_metrics_foundations",
+            sql: migration_0014_turn_metrics_foundations(schema),
+        },
     ];
 }
 
@@ -1752,6 +1762,277 @@ BEGIN
     LEFT JOIN ${s}.session_owners so ON so.session_id = sess.session_id
     LEFT JOIN ${s}.users u ON u.user_id = so.user_id
     WHERE sess.session_id = p_session_id AND sess.deleted_at IS NULL;
+END;
+$$ LANGUAGE plpgsql;
+`;
+}
+
+// ─── Migration 0013: Bounded Session Reads And Emitters ──────────
+
+function migration_0013_bounded_session_reads_and_emitters(schema: string): string {
+    const s = `"${schema}"`;
+    return `
+-- 0013_bounded_session_reads_and_emitters:
+--   Adds keyset-paginated session listing, bounded event-emitter diagnostics,
+--   and SQL-side caps for session event history reads.
+
+-- ── cms_list_sessions_page ───────────────────────────────────────
+-- Keyset-paginated session listing ordered by updated_at DESC, session_id DESC.
+-- Callers can request limit+1 rows later to compute hasMore without a count query.
+CREATE OR REPLACE FUNCTION ${s}.cms_list_sessions_page(
+    p_limit             INT         DEFAULT 51,
+    p_cursor_updated_at TIMESTAMPTZ DEFAULT NULL,
+    p_cursor_session_id TEXT        DEFAULT NULL,
+    p_include_deleted   BOOL        DEFAULT FALSE
+) RETURNS SETOF ${s}.sessions AS $$
+DECLARE
+    v_limit INT := GREATEST(1, LEAST(COALESCE(p_limit, 51), 201));
+BEGIN
+    RETURN QUERY
+    SELECT * FROM ${s}.sessions s
+    WHERE
+        (p_include_deleted OR s.deleted_at IS NULL)
+        AND (
+            p_cursor_updated_at IS NULL
+            OR s.updated_at < p_cursor_updated_at
+            OR (s.updated_at = p_cursor_updated_at AND s.session_id < p_cursor_session_id)
+        )
+    ORDER BY s.updated_at DESC, s.session_id DESC
+    LIMIT v_limit;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── cms_get_session_events (bounded) ─────────────────────────────
+CREATE OR REPLACE FUNCTION ${s}.cms_get_session_events(
+    p_session_id TEXT,
+    p_after_seq  BIGINT,
+    p_limit      INT
+) RETURNS SETOF ${s}.session_events AS $$
+DECLARE
+    v_limit INT := GREATEST(1, LEAST(COALESCE(p_limit, 200), 500));
+BEGIN
+    IF p_after_seq IS NOT NULL AND p_after_seq > 0 THEN
+        RETURN QUERY
+        SELECT * FROM ${s}.session_events
+        WHERE session_id = p_session_id AND seq > p_after_seq
+        ORDER BY seq ASC LIMIT v_limit;
+    ELSE
+        RETURN QUERY
+        SELECT * FROM (
+            SELECT * FROM ${s}.session_events
+            WHERE session_id = p_session_id
+            ORDER BY seq DESC LIMIT v_limit
+        ) t ORDER BY seq ASC;
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── cms_get_session_events_before (bounded) ──────────────────────
+CREATE OR REPLACE FUNCTION ${s}.cms_get_session_events_before(
+    p_session_id  TEXT,
+    p_before_seq  BIGINT,
+    p_limit       INT
+) RETURNS SETOF ${s}.session_events AS $$
+DECLARE
+    v_limit INT := GREATEST(1, LEAST(COALESCE(p_limit, 200), 500));
+BEGIN
+    RETURN QUERY
+    SELECT * FROM (
+        SELECT * FROM ${s}.session_events
+        WHERE session_id = p_session_id AND seq < p_before_seq
+        ORDER BY seq DESC LIMIT v_limit
+    ) t ORDER BY seq ASC;
+END;
+$$ LANGUAGE plpgsql;
+
+-- ── cms_get_top_event_emitters ───────────────────────────────────
+CREATE OR REPLACE FUNCTION ${s}.cms_get_top_event_emitters(
+    p_since TIMESTAMPTZ,
+    p_limit INT
+) RETURNS TABLE (
+    worker_node_id TEXT,
+    event_type     TEXT,
+    event_count    BIGINT,
+    session_count  BIGINT,
+    first_seen_at  TIMESTAMPTZ,
+    last_seen_at   TIMESTAMPTZ
+) AS $$
+DECLARE
+    v_limit INT := GREATEST(1, LEAST(COALESCE(p_limit, 20), 100));
+BEGIN
+    RETURN QUERY
+    SELECT
+        se.worker_node_id,
+        se.event_type,
+        COUNT(*)::BIGINT                      AS event_count,
+        COUNT(DISTINCT se.session_id)::BIGINT AS session_count,
+        MIN(se.created_at)                    AS first_seen_at,
+        MAX(se.created_at)                    AS last_seen_at
+    FROM ${s}.session_events se
+    WHERE se.worker_node_id IS NOT NULL
+      AND se.created_at >= COALESCE(p_since, now() - INTERVAL '24 hours')
+    GROUP BY se.worker_node_id, se.event_type
+    ORDER BY event_count DESC, last_seen_at DESC
+    LIMIT v_limit;
+END;
+$$ LANGUAGE plpgsql;
+`;
+}
+
+// ─── Migration 0014: Turn Metrics Foundations ───────────────────
+
+function migration_0014_turn_metrics_foundations(schema: string): string {
+    const s = `"${schema}"`;
+    return `
+-- 0014_turn_metrics_foundations:
+--   Adds per-turn analytics storage and bounded turn-metrics read functions.
+
+CREATE TABLE IF NOT EXISTS ${s}.session_turn_metrics (
+    id                  BIGSERIAL PRIMARY KEY,
+    session_id          TEXT        NOT NULL,
+    agent_id            TEXT,
+    model               TEXT,
+    turn_index          INTEGER     NOT NULL,
+    started_at          TIMESTAMPTZ NOT NULL,
+    ended_at            TIMESTAMPTZ NOT NULL,
+    duration_ms         INTEGER     NOT NULL CHECK (duration_ms >= 0),
+    tokens_input        BIGINT      NOT NULL DEFAULT 0,
+    tokens_output       BIGINT      NOT NULL DEFAULT 0,
+    tokens_cache_read   BIGINT      NOT NULL DEFAULT 0,
+    tokens_cache_write  BIGINT      NOT NULL DEFAULT 0,
+    tool_calls          INTEGER     NOT NULL DEFAULT 0,
+    tool_errors         INTEGER     NOT NULL DEFAULT 0,
+    result_type         TEXT,
+    error_message       TEXT,
+    worker_node_id      TEXT,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CHECK (ended_at >= started_at)
+);
+
+CREATE INDEX IF NOT EXISTS idx_${schema}_turn_metrics_session_idx
+    ON ${s}.session_turn_metrics(session_id, turn_index DESC);
+CREATE INDEX IF NOT EXISTS idx_${schema}_turn_metrics_started
+    ON ${s}.session_turn_metrics(started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_${schema}_turn_metrics_agent_started
+    ON ${s}.session_turn_metrics(agent_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS idx_${schema}_turn_metrics_model_started
+    ON ${s}.session_turn_metrics(model, started_at DESC);
+
+CREATE OR REPLACE FUNCTION ${s}.cms_insert_turn_metric(
+    p_session_id         TEXT,
+    p_agent_id           TEXT,
+    p_model              TEXT,
+    p_turn_index         INTEGER,
+    p_started_at         TIMESTAMPTZ,
+    p_ended_at           TIMESTAMPTZ,
+    p_duration_ms        INTEGER,
+    p_tokens_input       BIGINT,
+    p_tokens_output      BIGINT,
+    p_tokens_cache_read  BIGINT,
+    p_tokens_cache_write BIGINT,
+    p_tool_calls         INTEGER,
+    p_tool_errors        INTEGER,
+    p_result_type        TEXT,
+    p_error_message      TEXT,
+    p_worker_node_id     TEXT
+) RETURNS VOID AS $$
+BEGIN
+    INSERT INTO ${s}.session_turn_metrics (
+        session_id, agent_id, model, turn_index,
+        started_at, ended_at, duration_ms,
+        tokens_input, tokens_output, tokens_cache_read, tokens_cache_write,
+        tool_calls, tool_errors, result_type, error_message, worker_node_id
+    ) VALUES (
+        p_session_id, p_agent_id, p_model, p_turn_index,
+        p_started_at, p_ended_at, p_duration_ms,
+        p_tokens_input, p_tokens_output, p_tokens_cache_read, p_tokens_cache_write,
+        p_tool_calls, p_tool_errors, p_result_type, p_error_message, p_worker_node_id
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ${s}.cms_get_session_turn_metrics(
+    p_session_id TEXT,
+    p_since      TIMESTAMPTZ DEFAULT NULL,
+    p_limit      INT         DEFAULT 200
+) RETURNS TABLE (
+    id                  BIGINT,
+    session_id          TEXT,
+    agent_id            TEXT,
+    model               TEXT,
+    turn_index          INT,
+    started_at          TIMESTAMPTZ,
+    ended_at            TIMESTAMPTZ,
+    duration_ms         INT,
+    tokens_input        BIGINT,
+    tokens_output       BIGINT,
+    tokens_cache_read   BIGINT,
+    tokens_cache_write  BIGINT,
+    tool_calls          INT,
+    tool_errors         INT,
+    result_type         TEXT,
+    error_message       TEXT,
+    worker_node_id      TEXT,
+    created_at          TIMESTAMPTZ
+) AS $$
+DECLARE
+    v_limit INT := GREATEST(1, LEAST(COALESCE(p_limit, 200), 500));
+BEGIN
+    RETURN QUERY
+    SELECT
+        t.id, t.session_id, t.agent_id, t.model, t.turn_index,
+        t.started_at, t.ended_at, t.duration_ms,
+        t.tokens_input, t.tokens_output, t.tokens_cache_read, t.tokens_cache_write,
+        t.tool_calls, t.tool_errors, t.result_type, t.error_message,
+        t.worker_node_id, t.created_at
+    FROM ${s}.session_turn_metrics t
+    WHERE t.session_id = p_session_id
+      AND (p_since IS NULL OR t.started_at >= p_since)
+    ORDER BY t.turn_index DESC, t.id DESC
+    LIMIT v_limit;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ${s}.cms_get_hourly_token_buckets(
+    p_since    TIMESTAMPTZ,
+    p_agent_id TEXT DEFAULT NULL,
+    p_model    TEXT DEFAULT NULL
+) RETURNS TABLE (
+    hour_bucket              TIMESTAMPTZ,
+    turn_count               BIGINT,
+    total_tokens_input       BIGINT,
+    total_tokens_output      BIGINT,
+    total_tokens_cache_read  BIGINT,
+    total_tokens_cache_write BIGINT
+) AS $$
+BEGIN
+    RETURN QUERY
+    SELECT
+        date_trunc('hour', t.started_at)                AS hour_bucket,
+        COUNT(*)::bigint                                AS turn_count,
+        COALESCE(SUM(t.tokens_input), 0)::bigint        AS total_tokens_input,
+        COALESCE(SUM(t.tokens_output), 0)::bigint       AS total_tokens_output,
+        COALESCE(SUM(t.tokens_cache_read), 0)::bigint   AS total_tokens_cache_read,
+        COALESCE(SUM(t.tokens_cache_write), 0)::bigint  AS total_tokens_cache_write
+    FROM ${s}.session_turn_metrics t
+    WHERE t.started_at >= p_since
+      AND (p_agent_id IS NULL OR t.agent_id = p_agent_id)
+      AND (p_model IS NULL OR t.model = p_model)
+    GROUP BY date_trunc('hour', t.started_at)
+    ORDER BY hour_bucket DESC;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ${s}.cms_prune_turn_metrics(
+    p_older_than TIMESTAMPTZ
+) RETURNS INT AS $$
+DECLARE
+    v_deleted INT;
+BEGIN
+    DELETE FROM ${s}.session_turn_metrics
+    WHERE started_at < p_older_than;
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
 END;
 $$ LANGUAGE plpgsql;
 `;

--- a/packages/sdk/src/cms.ts
+++ b/packages/sdk/src/cms.ts
@@ -23,6 +23,65 @@ export interface SessionEvent {
     workerNodeId?: string;
 }
 
+/** One row from cms_get_top_event_emitters. */
+export interface TopEventEmitterRow {
+    workerNodeId: string;
+    eventType: string;
+    eventCount: number;
+    sessionCount: number;
+    firstSeenAt: Date | null;
+    lastSeenAt: Date | null;
+}
+
+export interface InsertTurnMetricInput {
+    sessionId: string;
+    agentId: string | null;
+    model: string | null;
+    turnIndex: number;
+    startedAt: Date;
+    endedAt: Date;
+    durationMs: number;
+    tokensInput: number;
+    tokensOutput: number;
+    tokensCacheRead: number;
+    tokensCacheWrite: number;
+    toolCalls: number;
+    toolErrors: number;
+    resultType: string | null;
+    errorMessage: string | null;
+    workerNodeId: string | null;
+}
+
+export interface TurnMetricRow {
+    id: number;
+    sessionId: string;
+    agentId: string | null;
+    model: string | null;
+    turnIndex: number;
+    startedAt: Date;
+    endedAt: Date;
+    durationMs: number;
+    tokensInput: number;
+    tokensOutput: number;
+    tokensCacheRead: number;
+    tokensCacheWrite: number;
+    toolCalls: number;
+    toolErrors: number;
+    resultType: string | null;
+    errorMessage: string | null;
+    workerNodeId: string | null;
+    createdAt: Date;
+}
+
+export interface HourlyTokenBucketRow {
+    hourBucket: Date;
+    turnCount: number;
+    totalTokensInput: number;
+    totalTokensOutput: number;
+    totalTokensCacheRead: number;
+    totalTokensCacheWrite: number;
+}
+
 /** A row in the sessions table. */
 export interface SessionRow {
     sessionId: string;
@@ -343,6 +402,14 @@ export interface SessionCatalogProvider {
     /** List all non-deleted sessions, newest first. */
     listSessions(): Promise<SessionRow[]>;
 
+    /** List one bounded page of sessions, newest first. */
+    listSessionsPage(opts?: {
+        limit?: number;
+        cursorUpdatedAt?: Date | null;
+        cursorSessionId?: string | null;
+        includeDeleted?: boolean;
+    }): Promise<SessionRow[]>;
+
     /** Get a single session by ID (null if not found or deleted). */
     getSession(sessionId: string): Promise<SessionRow | null>;
 
@@ -362,6 +429,21 @@ export interface SessionCatalogProvider {
 
     /** Get events before a sequence number, ordered ascending by seq. */
     getSessionEventsBefore(sessionId: string, beforeSeq: number, limit?: number): Promise<SessionEvent[]>;
+
+    /** Get the highest-volume event emitters since a point in time. */
+    getTopEventEmitters(since: Date, limit?: number): Promise<TopEventEmitterRow[]>;
+
+    /** Insert one per-turn metrics row. */
+    insertTurnMetric(input: InsertTurnMetricInput): Promise<void>;
+
+    /** Get bounded per-session turn metrics, newest-first. */
+    getSessionTurnMetrics(sessionId: string, opts?: { since?: Date; limit?: number }): Promise<TurnMetricRow[]>;
+
+    /** Aggregate hourly token buckets from session turn metrics. */
+    getHourlyTokenBuckets(since: Date, opts?: { agentId?: string; model?: string }): Promise<HourlyTokenBucketRow[]>;
+
+    /** Delete turn metrics older than a cutoff and return deleted row count. */
+    pruneTurnMetrics(olderThan: Date): Promise<number>;
 
     // ── Session Metric Summaries ──────────────────────────────
 
@@ -447,12 +529,18 @@ function sqlForSchema(schema: string) {
             updateSession:              `${s}.cms_update_session`,
             softDeleteSession:          `${s}.cms_soft_delete_session`,
             listSessions:               `${s}.cms_list_sessions`,
+            listSessionsPage:           `${s}.cms_list_sessions_page`,
             getSession:                 `${s}.cms_get_session`,
             getDescendantSessionIds:    `${s}.cms_get_descendant_session_ids`,
             getLastSessionId:           `${s}.cms_get_last_session_id`,
             recordEvents:               `${s}.cms_record_events`,
             getSessionEvents:           `${s}.cms_get_session_events`,
             getSessionEventsBefore:     `${s}.cms_get_session_events_before`,
+            getTopEventEmitters:        `${s}.cms_get_top_event_emitters`,
+            insertTurnMetric:           `${s}.cms_insert_turn_metric`,
+            getSessionTurnMetrics:      `${s}.cms_get_session_turn_metrics`,
+            getHourlyTokenBuckets:      `${s}.cms_get_hourly_token_buckets`,
+            pruneTurnMetrics:           `${s}.cms_prune_turn_metrics`,
             getSessionMetricSummary:    `${s}.cms_get_session_metric_summary`,
             getSessionTreeStats:        `${s}.cms_get_session_tree_stats`,
             getSessionTreeStatsByModel: `${s}.cms_get_session_tree_stats_by_model`,
@@ -615,6 +703,24 @@ export class PgSessionCatalogProvider implements SessionCatalogProvider {
         return rows.map(rowToSessionRow);
     }
 
+    async listSessionsPage(opts?: {
+        limit?: number;
+        cursorUpdatedAt?: Date | null;
+        cursorSessionId?: string | null;
+        includeDeleted?: boolean;
+    }): Promise<SessionRow[]> {
+        const { rows } = await this.pool.query(
+            `SELECT * FROM ${this.sql.fn.listSessionsPage}($1, $2, $3, $4)`,
+            [
+                opts?.limit ?? null,
+                opts?.cursorUpdatedAt ?? null,
+                opts?.cursorSessionId ?? null,
+                opts?.includeDeleted ?? false,
+            ],
+        );
+        return rows.map(rowToSessionRow);
+    }
+
     async getSession(sessionId: string): Promise<SessionRow | null> {
         const { rows } = await this.pool.query(
             `SELECT * FROM ${this.sql.fn.getSession}($1)`,
@@ -665,6 +771,62 @@ export class PgSessionCatalogProvider implements SessionCatalogProvider {
             [sessionId, beforeSeq, effectiveLimit],
         );
         return rows.map(rowToSessionEvent);
+    }
+
+    async getTopEventEmitters(since: Date, limit?: number): Promise<TopEventEmitterRow[]> {
+        const { rows } = await this.pool.query(
+            `SELECT * FROM ${this.sql.fn.getTopEventEmitters}($1, $2)`,
+            [since, limit ?? null],
+        );
+        return rows.map(rowToTopEventEmitterRow);
+    }
+
+    async insertTurnMetric(input: InsertTurnMetricInput): Promise<void> {
+        await this.pool.query(
+            `SELECT ${this.sql.fn.insertTurnMetric}($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+            [
+                input.sessionId,
+                input.agentId,
+                input.model,
+                input.turnIndex,
+                input.startedAt,
+                input.endedAt,
+                input.durationMs,
+                input.tokensInput,
+                input.tokensOutput,
+                input.tokensCacheRead,
+                input.tokensCacheWrite,
+                input.toolCalls,
+                input.toolErrors,
+                input.resultType,
+                input.errorMessage,
+                input.workerNodeId,
+            ],
+        );
+    }
+
+    async getSessionTurnMetrics(sessionId: string, opts?: { since?: Date; limit?: number }): Promise<TurnMetricRow[]> {
+        const { rows } = await this.pool.query(
+            `SELECT * FROM ${this.sql.fn.getSessionTurnMetrics}($1, $2, $3)`,
+            [sessionId, opts?.since ?? null, opts?.limit ?? null],
+        );
+        return rows.map(rowToTurnMetricRow);
+    }
+
+    async getHourlyTokenBuckets(since: Date, opts?: { agentId?: string; model?: string }): Promise<HourlyTokenBucketRow[]> {
+        const { rows } = await this.pool.query(
+            `SELECT * FROM ${this.sql.fn.getHourlyTokenBuckets}($1, $2, $3)`,
+            [since, opts?.agentId ?? null, opts?.model ?? null],
+        );
+        return rows.map(rowToHourlyTokenBucketRow);
+    }
+
+    async pruneTurnMetrics(olderThan: Date): Promise<number> {
+        const { rows } = await this.pool.query(
+            `SELECT ${this.sql.fn.pruneTurnMetrics}($1) AS deleted_count`,
+            [olderThan],
+        );
+        return Number(rows[0]?.deleted_count) || 0;
     }
 
     // ── Session Metric Summaries ─────────────────────────────
@@ -1117,6 +1279,52 @@ function rowToSessionEvent(row: any): SessionEvent {
         data: row.data,
         createdAt: new Date(row.created_at),
         workerNodeId: row.worker_node_id ?? undefined,
+    };
+}
+
+/** Map a PG row to TopEventEmitterRow. */
+function rowToTopEventEmitterRow(row: any): TopEventEmitterRow {
+    return {
+        workerNodeId: String(row.worker_node_id),
+        eventType: String(row.event_type),
+        eventCount: Number(row.event_count) || 0,
+        sessionCount: Number(row.session_count) || 0,
+        firstSeenAt: row.first_seen_at ? new Date(row.first_seen_at) : null,
+        lastSeenAt: row.last_seen_at ? new Date(row.last_seen_at) : null,
+    };
+}
+
+function rowToTurnMetricRow(row: any): TurnMetricRow {
+    return {
+        id: Number(row.id),
+        sessionId: row.session_id,
+        agentId: row.agent_id ?? null,
+        model: row.model ?? null,
+        turnIndex: Number(row.turn_index) || 0,
+        startedAt: new Date(row.started_at),
+        endedAt: new Date(row.ended_at),
+        durationMs: Number(row.duration_ms) || 0,
+        tokensInput: Number(row.tokens_input) || 0,
+        tokensOutput: Number(row.tokens_output) || 0,
+        tokensCacheRead: Number(row.tokens_cache_read) || 0,
+        tokensCacheWrite: Number(row.tokens_cache_write) || 0,
+        toolCalls: Number(row.tool_calls) || 0,
+        toolErrors: Number(row.tool_errors) || 0,
+        resultType: row.result_type ?? null,
+        errorMessage: row.error_message ?? null,
+        workerNodeId: row.worker_node_id ?? null,
+        createdAt: new Date(row.created_at),
+    };
+}
+
+function rowToHourlyTokenBucketRow(row: any): HourlyTokenBucketRow {
+    return {
+        hourBucket: new Date(row.hour_bucket),
+        turnCount: Number(row.turn_count) || 0,
+        totalTokensInput: Number(row.total_tokens_input) || 0,
+        totalTokensOutput: Number(row.total_tokens_output) || 0,
+        totalTokensCacheRead: Number(row.total_tokens_cache_read) || 0,
+        totalTokensCacheWrite: Number(row.total_tokens_cache_write) || 0,
     };
 }
 

--- a/packages/sdk/test/local/cms-read-bounds.integration.test.js
+++ b/packages/sdk/test/local/cms-read-bounds.integration.test.js
@@ -1,0 +1,173 @@
+/**
+ * CMS bounded read integration tests.
+ */
+
+import { describe, it } from "vitest";
+import { useSuiteEnv } from "../helpers/local-env.js";
+import { assert, assertEqual, assertGreaterOrEqual } from "../helpers/assertions.js";
+import { PgSessionCatalogProvider } from "../../src/index.ts";
+
+const TIMEOUT = 180_000;
+const getEnv = useSuiteEnv(import.meta.url);
+
+function makeEvents(count, prefix) {
+    return Array.from({ length: count }, (_, i) => ({
+        eventType: `${prefix}.${i % 3}`,
+        data: { index: i, prefix },
+    }));
+}
+
+async function directQuery(env, sql, params = []) {
+    const { default: pg } = await import("pg");
+    const client = new pg.Client({ connectionString: env.store });
+    try {
+        await client.connect();
+        return await client.query(sql, params);
+    } finally {
+        try { await client.end(); } catch {}
+    }
+}
+
+describe("CMS read bounds", () => {
+    it("pages sessions by updated_at/session_id in bounded slices", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+
+        try {
+            await catalog.initialize();
+
+            const sessionIds = ["s-001", "s-002", "s-003", "s-004", "s-005"];
+            for (const sessionId of sessionIds) {
+                await catalog.createSession(sessionId, { model: "gpt-5.4" });
+            }
+
+            await catalog.updateSession("s-001", { state: "running" });
+            await catalog.updateSession("s-002", { state: "running" });
+            await catalog.updateSession("s-003", { state: "running" });
+            await catalog.updateSession("s-004", { state: "running" });
+            await catalog.updateSession("s-005", { state: "running" });
+
+            const firstPage = await catalog.listSessionsPage({ limit: 2 });
+            assertEqual(firstPage.length, 2, "First page should contain 2 rows");
+
+            const cursor = firstPage[firstPage.length - 1];
+            const secondPage = await catalog.listSessionsPage({
+                limit: 2,
+                cursorUpdatedAt: cursor.updatedAt,
+                cursorSessionId: cursor.sessionId,
+            });
+
+            assertEqual(secondPage.length, 2, "Second page should contain 2 rows");
+            const seen = new Set([...firstPage, ...secondPage].map((s) => s.sessionId));
+            assertEqual(seen.size, 4, "Paged reads should not repeat session rows");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+
+    it("clamps oversized latest-event reads in SQL", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+
+        try {
+            await catalog.initialize();
+
+            const sessionId = `events-${Date.now()}`;
+            await catalog.createSession(sessionId, { model: "gpt-5.4" });
+            await directQuery(
+                env,
+                `INSERT INTO "${env.cmsSchema}".session_events (session_id, event_type, data, worker_node_id)
+                 SELECT
+                   $1,
+                   'history.' || ((gs - 1) % 3)::text,
+                   jsonb_build_object('index', gs - 1, 'prefix', 'history'),
+                   'worker-a'
+                 FROM generate_series(1, 520) AS gs`,
+                [sessionId],
+            );
+
+            const { rows: latest } = await directQuery(
+                env,
+                `SELECT *
+                 FROM "${env.cmsSchema}".cms_get_session_events($1, $2, $3)`,
+                [sessionId, null, 10_000],
+            );
+            assertEqual(latest.length, 500, "getSessionEvents should clamp to 500 rows");
+            assert(latest[0].seq < latest[latest.length - 1].seq, "Latest events should be returned in ascending seq order");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+
+    it("clamps oversized older-event reads in SQL", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+
+        try {
+            await catalog.initialize();
+
+            const sessionId = `events-before-${Date.now()}`;
+            await catalog.createSession(sessionId, { model: "gpt-5.4" });
+            await directQuery(
+                env,
+                `INSERT INTO "${env.cmsSchema}".session_events (session_id, event_type, data, worker_node_id)
+                 SELECT
+                   $1,
+                   'history.' || ((gs - 1) % 3)::text,
+                   jsonb_build_object('index', gs - 1, 'prefix', 'history'),
+                   'worker-a'
+                 FROM generate_series(1, 520) AS gs`,
+                [sessionId],
+            );
+
+            const { rows: latest } = await directQuery(
+                env,
+                `SELECT *
+                 FROM "${env.cmsSchema}".cms_get_session_events($1, $2, $3)`,
+                [sessionId, null, 10_000],
+            );
+            const beforeCursor = latest[latest.length - 1].seq;
+
+            const { rows: older } = await directQuery(
+                env,
+                `SELECT *
+                 FROM "${env.cmsSchema}".cms_get_session_events_before($1, $2, $3)`,
+                [sessionId, beforeCursor, 10_000],
+            );
+            assertGreaterOrEqual(older.length, 1, "Expected at least one older event page");
+            assert(older.length <= 500, "getSessionEventsBefore should clamp to 500 rows");
+            assert(older[0].seq < older[older.length - 1].seq, "Older events should be returned in ascending seq order");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+
+    it("returns bounded top event emitter diagnostics", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+
+        try {
+            await catalog.initialize();
+
+            const sessionA = `emit-a-${Date.now()}`;
+            const sessionB = `emit-b-${Date.now()}`;
+            await catalog.createSession(sessionA);
+            await catalog.createSession(sessionB);
+
+            await catalog.recordEvents(sessionA, makeEvents(12, "tool"), "worker-hot");
+            await catalog.recordEvents(sessionB, makeEvents(4, "tool"), "worker-cold");
+
+            const rows = await catalog.getTopEventEmitters(new Date(Date.now() - 60_000), 1_000);
+            assert(rows.length > 0, "Expected top event emitter rows");
+            assert(rows.length <= 100, "Top event emitter query should clamp its limit");
+
+            const hottest = rows[0];
+            assertEqual(hottest.workerNodeId, "worker-hot", "Expected busiest worker first");
+            assertGreaterOrEqual(hottest.eventCount, 4, "Top emitter should have aggregated event rows");
+            assert(hottest.firstSeenAt instanceof Date || hottest.firstSeenAt === null, "Expected firstSeenAt to be mapped");
+            assert(hottest.lastSeenAt instanceof Date || hottest.lastSeenAt === null, "Expected lastSeenAt to be mapped");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+});

--- a/packages/sdk/test/local/cms-turn-metrics.integration.test.js
+++ b/packages/sdk/test/local/cms-turn-metrics.integration.test.js
@@ -1,0 +1,119 @@
+import { describe, it, beforeAll } from "vitest";
+import { useSuiteEnv } from "../helpers/local-env.js";
+import { assert, assertEqual } from "../helpers/assertions.js";
+import { PgSessionCatalogProvider } from "../../src/index.ts";
+
+const TIMEOUT = 180_000;
+const getEnv = useSuiteEnv(import.meta.url);
+
+async function directQuery(env, sql, params = []) {
+    const { default: pg } = await import("pg");
+    const client = new pg.Client({ connectionString: env.store });
+    try {
+        await client.connect();
+        return await client.query(sql, params);
+    } finally {
+        try { await client.end(); } catch {}
+    }
+}
+
+describe("CMS turn metrics integration", () => {
+    beforeAll(async () => {
+        const env = getEnv();
+        const { default: pg } = await import("pg");
+        const client = new pg.Client({
+            connectionString: env.store,
+            connectionTimeoutMillis: 4000,
+        });
+        try {
+            await client.connect();
+            await client.query("SELECT 1");
+        } finally {
+            try { await client.end(); } catch {}
+        }
+    });
+
+    it("default getSessionTurnMetrics limit is 200", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+        await catalog.initialize();
+
+        try {
+            const sid = `turn-metrics-limit-${Date.now()}`;
+            await catalog.createSession(sid, { agentId: "ag-1", model: "claude-sonnet-4-6" });
+
+            await directQuery(
+                env,
+                `
+                INSERT INTO "${env.cmsSchema}".session_turn_metrics (
+                    session_id, agent_id, model, turn_index,
+                    started_at, ended_at, duration_ms,
+                    tokens_input, tokens_output, tokens_cache_read, tokens_cache_write,
+                    tool_calls, tool_errors, result_type, error_message, worker_node_id
+                )
+                SELECT
+                    $1, 'ag-1', 'claude-sonnet-4-6', gs,
+                    now() - (gs || ' seconds')::interval,
+                    now() - ((gs - 1) || ' seconds')::interval,
+                    1000,
+                    10, 5, 1, 0,
+                    1, 0, 'completed', NULL, 'wk-1'
+                FROM generate_series(1, 250) AS gs
+                `,
+                [sid],
+            );
+
+            const rows = await catalog.getSessionTurnMetrics(sid);
+            assertEqual(rows.length, 200, "default limit should return 200 rows");
+            assertEqual(rows[0].turnIndex, 250, "newest row should be first");
+            assertEqual(rows[199].turnIndex, 51, "200th row should match descending limit");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+
+    it("hourly bucket rows contain only hourly aggregate fields", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+        await catalog.initialize();
+
+        try {
+            const sid = `turn-hourly-${Date.now()}`;
+            await catalog.createSession(sid, { agentId: "ag-hourly", model: "claude-opus-4-7" });
+
+            const now = new Date();
+            await catalog.insertTurnMetric({
+                sessionId: sid,
+                agentId: "ag-hourly",
+                model: "claude-opus-4-7",
+                turnIndex: 1,
+                startedAt: new Date(now.getTime() - 5_000),
+                endedAt: now,
+                durationMs: 5_000,
+                tokensInput: 120,
+                tokensOutput: 80,
+                tokensCacheRead: 10,
+                tokensCacheWrite: 5,
+                toolCalls: 1,
+                toolErrors: 0,
+                resultType: "completed",
+                errorMessage: null,
+                workerNodeId: "wk-hourly",
+            });
+
+            const buckets = await catalog.getHourlyTokenBuckets(
+                new Date(now.getTime() - 2 * 60 * 60 * 1000),
+                { agentId: "ag-hourly", model: "claude-opus-4-7" },
+            );
+
+            assert(buckets.length >= 1, "expected at least one hourly bucket");
+            const row = buckets[0];
+            assert(row.hourBucket instanceof Date, "hourBucket should be Date");
+            assert(typeof row.turnCount === "number", "turnCount should be numeric");
+            assert(!("agentId" in row), "hourly row should not expose agentId");
+            assert(!("model" in row), "hourly row should not expose model");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+});

--- a/packages/sdk/test/local/pg-migrator.test.js
+++ b/packages/sdk/test/local/pg-migrator.test.js
@@ -1,0 +1,64 @@
+/**
+ * CMS migration application tests for bounded session reads.
+ */
+
+import { describe, it } from "vitest";
+import { useSuiteEnv } from "../helpers/local-env.js";
+import { assert, assertEqual } from "../helpers/assertions.js";
+import { PgSessionCatalogProvider } from "../../src/index.ts";
+
+const TIMEOUT = 60_000;
+const getEnv = useSuiteEnv(import.meta.url);
+
+async function directQuery(env, sql, params = []) {
+    const { default: pg } = await import("pg");
+    const client = new pg.Client({ connectionString: env.store });
+    try {
+        await client.connect();
+        return await client.query(sql, params);
+    } finally {
+        try { await client.end(); } catch {}
+    }
+}
+
+describe("CMS migrator — bounded session reads", () => {
+    it("applies migration 0013 and creates bounded read functions", async () => {
+        const env = getEnv();
+        const catalog = await PgSessionCatalogProvider.create(env.store, env.cmsSchema);
+
+        try {
+            await catalog.initialize();
+
+            const { rows: versions } = await directQuery(
+                env,
+                `SELECT version FROM "${env.cmsSchema}".schema_migrations ORDER BY version`,
+            );
+            const appliedVersions = versions.map((r) => r.version);
+            assert(appliedVersions.includes("0013"), "Expected migration 0013 to be applied");
+
+            const { rows: routines } = await directQuery(
+                env,
+                `SELECT routine_name
+                 FROM information_schema.routines
+                 WHERE routine_schema = $1
+                   AND routine_name IN (
+                     'cms_list_sessions_page',
+                     'cms_get_top_event_emitters',
+                     'cms_get_session_events',
+                     'cms_get_session_events_before'
+                   )
+                 ORDER BY routine_name`,
+                [env.cmsSchema],
+            );
+
+            const routineNames = routines.map((r) => r.routine_name);
+            assertEqual(routineNames.length, 4, "Expected all bounded read routines to exist");
+            assert(routineNames.includes("cms_list_sessions_page"), "Missing cms_list_sessions_page");
+            assert(routineNames.includes("cms_get_top_event_emitters"), "Missing cms_get_top_event_emitters");
+            assert(routineNames.includes("cms_get_session_events"), "Missing cms_get_session_events");
+            assert(routineNames.includes("cms_get_session_events_before"), "Missing cms_get_session_events_before");
+        } finally {
+            await catalog.close();
+        }
+    }, TIMEOUT);
+});


### PR DESCRIPTION
## Summary

This PR adds the first storage-focused slice of the DB optimization work on top of the latest `upstream/main`.

The changes focus on:

- adding bounded session paging at the CMS storage layer
- adding bounded top-emitter diagnostics at the CMS storage layer
- enforcing SQL-side limits for event-history reads
- adding turn-metrics storage foundations and bounded turn-metrics reads
- validating the new storage contracts with focused migration and integration tests

This is a narrow storage-layer PR. It does not include portal runtime guardrails, browser/CLI transport changes, management-client forwarding changes, or DB metrics reporting work.

## Motivation

PilotSwarm already supports durable orchestration, CMS-backed session state, and management tooling, but some DB-backed read paths were still too open-ended at the storage layer.

This PR addresses:

- full-list session browsing that needs a paged storage primitive
- event-history reads that previously trusted caller-provided limits directly
- missing storage-level diagnostics for noisy event emitters
- missing bounded turn-metrics storage/read foundations for later analytics and reporting work

The goal is to make the DB contract safer before higher layers adopt these read paths more broadly.

## What This PR Brings

- keyset-paginated session listing through `cms_list_sessions_page(...)`
- bounded event-emitter diagnostics through `cms_get_top_event_emitters(...)`
- SQL-side limit clamping for:
  - `cms_get_session_events(...)`
  - `cms_get_session_events_before(...)`
  - `cms_get_session_turn_metrics(...)`
- turn-metrics table and storage functions for per-turn analytics foundations
- CMS provider wiring for the new storage functions
- focused migration and integration coverage for this slice

## What's Added

`packages/sdk/src/`

- `cms-migrations.ts` — adds migration `0013` for bounded session reads and emitters, plus migration `0014` for turn-metrics foundations
- `cms.ts` — adds CMS provider types and wrappers for session paging, top emitters, turn metrics, hourly token buckets, and turn-metric pruning

`packages/sdk/test/local/`

- `pg-migrator.test.js` — verifies the new bounded-read migration functions are applied
- `cms-read-bounds.integration.test.js` — verifies session paging, bounded event reads, and top-emitter diagnostics
- `cms-turn-metrics.integration.test.js` — verifies bounded turn-metrics reads and hourly token bucket behavior

## Scope

In scope:

- `packages/sdk/src/cms-migrations.ts`
- `packages/sdk/src/cms.ts`
- `packages/sdk/test/local/pg-migrator.test.js`
- `packages/sdk/test/local/cms-read-bounds.integration.test.js`
- `packages/sdk/test/local/cms-turn-metrics.integration.test.js`

Out of scope:

- portal runtime changes
- browser transport changes
- CLI transport changes
- management-client forwarding changes
- DB metrics reporter changes
- monitoring UI work

## Testing

Validated with targeted storage-layer coverage:

- `packages/sdk/test/local/pg-migrator.test.js`
- `packages/sdk/test/local/cms-read-bounds.integration.test.js`
- `packages/sdk/test/local/cms-turn-metrics.integration.test.js`

Result:

- `3` test files passed
- `7` tests passed

The tests were run successfully against a dedicated Neon-backed test database using isolated per-suite schemas.

## Reviewer Guidance

Suggested review order:

1. `packages/sdk/src/cms-migrations.ts` — new migrations and SQL contract changes
2. `packages/sdk/src/cms.ts` — provider wiring for the new storage functions
3. `packages/sdk/test/local/pg-migrator.test.js` — migration coverage
4. `packages/sdk/test/local/cms-read-bounds.integration.test.js`
5. `packages/sdk/test/local/cms-turn-metrics.integration.test.js`
