### PR TITLE
feat(sdk): route duroxide orchestration store through Entra in MI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,37 @@
 
 ## Unreleased
 
+## 0.1.29 — 2026-05-12
+
+### SDK / Runtime
+
+- **Passwordless duroxide orchestration store** — when configured with
+  `useManagedIdentity: true`, the worker, client, and management client now all
+  route the duroxide Postgres store through `PostgresProvider.connectWithSchemaAndEntra`
+  (added in duroxide-node 0.1.25) instead of `connectWithSchema`. CMS, facts,
+  **and** the orchestration store now authenticate via Microsoft Entra ID — no
+  password URL gap. The legacy password-in-URL path (`useManagedIdentity` unset
+  or `false`) is unchanged, so the existing `deploy-aks.sh` flow continues to
+  work without changes. URL parsing and AAD user resolution are shared with the
+  CMS/facts pg-pool factory via the new `parsePostgresUrl` /
+  `resolveAadPostgresUser` helpers. This closes the last gap blocking
+  pure-Entra cutover on AKS — the password store argument,
+  `passwordAuth: 'Enabled'` Bicep flag, and `postgres-admin-password` Key
+  Vault secret can now be dropped by downstream deployers.
+
+### Docs
+
+- Updated `README.md`, `deploy/scripts/README.md`, `deploy/envs/template.env`,
+  the worker + portal overlay `.env` files, the `postgres.bicep` auth comment,
+  and the `compose-env.mjs` rationale to reflect that the duroxide store now
+  honours the MI switch (no more "no token-callback hook upstream" caveat).
+
+### Tests
+
+- Added unit coverage for the new `duroxide-provider-factory` (legacy vs MI
+  routing, URL parsing defaults, missing-user error path) and refactored
+  `pg-pool-factory` to share parsing with it (existing tests unchanged).
+
 ## 0.1.28 — 2026-05-09
 
 ### SDK / Runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,16 @@
 
 ### SDK / Runtime
 
+- Bumped `duroxide` dependency from `^0.1.25` to `^0.1.26`. Duroxide 0.1.26
+  picks up `duroxide-pg` 0.1.33 / `duroxide-pg-opt` 0.1.29, which switch
+  `reqwest` to `default-features = false` + `native-tls`. Without this, the
+  AAD token-acquisition HTTPS call inside the orchestration store failed with
+  a TLS handshake error in containers using musl/OpenSSL, making the
+  `useManagedIdentity: true` path below unusable in practice.
 - **Passwordless duroxide orchestration store** — when configured with
   `useManagedIdentity: true`, the worker, client, and management client now all
   route the duroxide Postgres store through `PostgresProvider.connectWithSchemaAndEntra`
-  (added in duroxide-node 0.1.25) instead of `connectWithSchema`. CMS, facts,
+  (added in duroxide-node 0.1.25) instead of `connectWithSchema`.CMS, facts,
   **and** the orchestration store now authenticate via Microsoft Entra ID — no
   password URL gap. The legacy password-in-URL path (`useManagedIdentity` unset
   or `false`) is unchanged, so the existing `deploy-aks.sh` flow continues to

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Experimental** — This project is under active development and not yet ready for production use. APIs may change without notice.
 
-> **Latest release: v0.1.28** — Duroxide 0.1.25 with Entra ID / Azure AD passwordless authentication (`connectWithEntra`, `connectWithSchemaAndEntra`).
+> **Latest release: v0.1.29** — Passwordless duroxide orchestration store. When `useManagedIdentity: true`, the worker now routes the duroxide Postgres store through `connectWithSchemaAndEntra` (duroxide-node 0.1.25), so CMS, facts, **and** the orchestration store all authenticate via Entra ID — no more password URL gap.
 
 A durable execution runtime for [GitHub Copilot SDK](https://github.com/github/copilot-sdk) agents. Crash recovery, durable timers, session dehydration, and multi-node scaling — powered by [duroxide](https://github.com/microsoft/duroxide). Just add a connection string.
 

--- a/deploy/Dockerfile.portal
+++ b/deploy/Dockerfile.portal
@@ -3,7 +3,9 @@
 #
 # Build with: docker buildx build --platform linux/amd64 -f deploy/Dockerfile.portal ...
 
-FROM node:24-slim
+# trixie-slim (Debian 13, glibc 2.41) required by duroxide-linux-x64-gnu >= 0.1.25
+# (prebuilds link against GLIBC_2.39; bookworm-slim is 2.36 and crashes at dlopen).
+FROM node:24-trixie-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates python3 make g++ \

--- a/deploy/Dockerfile.worker
+++ b/deploy/Dockerfile.worker
@@ -1,5 +1,7 @@
 # Single-stage: install from npm (linux binary published to registry)
-FROM node:24-slim
+# trixie-slim (Debian 13, glibc 2.41) required by duroxide-linux-x64-gnu >= 0.1.25
+# (prebuilds link against GLIBC_2.39; bookworm-slim is 2.36 and crashes at dlopen).
+FROM node:24-trixie-slim
 
 # Install CA certificates for HTTPS
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/deploy/envs/template.env
+++ b/deploy/envs/template.env
@@ -137,10 +137,12 @@ INGRESS_CLASS=azure-application-gateway
 # populated by a prior bicep step. If the cache is empty, run with
 # `--steps bicep,manifests,rollout` once so the cache fills.
 
-# ─── Bicep-deploy MI feature switch (Chunks B + C) ───
+# ─── Bicep-deploy MI feature switch ───
 # Static for the bicep-deploy path. Causes worker to use DefaultAzureCredential
-# for blob storage (Chunk B) and AAD token callback for CMS+facts pools
-# (Chunk C). Legacy `scripts/deploy-aks.sh` does NOT consume these — its
+# for blob storage and AAD token callback for CMS+facts pools, and routes
+# the duroxide orchestration store through duroxide-node's native Entra
+# path (PostgresProvider.connectWithSchemaAndEntra, duroxide-node ≥
+# 0.1.25). Legacy `scripts/deploy-aks.sh` does NOT consume these — its
 # own K8s secret keeps the connection-string flow intact.
 PILOTSWARM_USE_MANAGED_IDENTITY=1
 AZURE_STORAGE_CONTAINER=copilot-sessions

--- a/deploy/gitops/portal/overlays/afd-akv/.env
+++ b/deploy/gitops/portal/overlays/afd-akv/.env
@@ -16,9 +16,11 @@ AZURE_STORAGE_ACCOUNT_URL=https://placeholder.blob.core.windows.net/
 # from POSTGRES_FQDN + POSTGRES_AAD_ADMIN_PRINCIPAL_NAME.
 PILOTSWARM_CMS_FACTS_DATABASE_URL=postgresql://placeholder@placeholder:5432/placeholder?sslmode=require
 PILOTSWARM_DB_AAD_USER=placeholder
-# DATABASE_URL is the password URL used by duroxide's PostgresProvider
-# (no AAD token-callback hook upstream). CMS + facts use the
-# PILOTSWARM_CMS_FACTS_DATABASE_URL above.
+# DATABASE_URL is the password URL kept available for the legacy
+# deploy-aks.sh flow and as a fallback when MI is not enabled. In MI
+# mode the duroxide store ignores any embedded password and
+# authenticates via duroxide-node's native Entra path; CMS + facts use
+# the PILOTSWARM_CMS_FACTS_DATABASE_URL above.
 DATABASE_URL=postgresql://placeholder:placeholder@placeholder:5432/placeholder?sslmode=require
 
 # SPC keys hash. Computed by deploy/scripts/lib/spc-keys-hash.mjs from

--- a/deploy/gitops/portal/overlays/afd-letsencrypt/.env
+++ b/deploy/gitops/portal/overlays/afd-letsencrypt/.env
@@ -16,9 +16,11 @@ AZURE_STORAGE_ACCOUNT_URL=https://placeholder.blob.core.windows.net/
 # from POSTGRES_FQDN + POSTGRES_AAD_ADMIN_PRINCIPAL_NAME.
 PILOTSWARM_CMS_FACTS_DATABASE_URL=postgresql://placeholder@placeholder:5432/placeholder?sslmode=require
 PILOTSWARM_DB_AAD_USER=placeholder
-# DATABASE_URL is the password URL used by duroxide's PostgresProvider
-# (no AAD token-callback hook upstream). CMS + facts use the
-# PILOTSWARM_CMS_FACTS_DATABASE_URL above.
+# DATABASE_URL is the password URL kept available for the legacy
+# deploy-aks.sh flow and as a fallback when MI is not enabled. In MI
+# mode the duroxide store ignores any embedded password and
+# authenticates via duroxide-node's native Entra path; CMS + facts use
+# the PILOTSWARM_CMS_FACTS_DATABASE_URL above.
 DATABASE_URL=postgresql://placeholder:placeholder@placeholder:5432/placeholder?sslmode=require
 
 # SPC keys hash. Computed by deploy/scripts/lib/spc-keys-hash.mjs from

--- a/deploy/gitops/portal/overlays/private-akv/.env
+++ b/deploy/gitops/portal/overlays/private-akv/.env
@@ -16,9 +16,11 @@ AZURE_STORAGE_ACCOUNT_URL=https://placeholder.blob.core.windows.net/
 # from POSTGRES_FQDN + POSTGRES_AAD_ADMIN_PRINCIPAL_NAME.
 PILOTSWARM_CMS_FACTS_DATABASE_URL=postgresql://placeholder@placeholder:5432/placeholder?sslmode=require
 PILOTSWARM_DB_AAD_USER=placeholder
-# DATABASE_URL is the password URL used by duroxide's PostgresProvider
-# (no AAD token-callback hook upstream). CMS + facts use the
-# PILOTSWARM_CMS_FACTS_DATABASE_URL above.
+# DATABASE_URL is the password URL kept available for the legacy
+# deploy-aks.sh flow and as a fallback when MI is not enabled. In MI
+# mode the duroxide store ignores any embedded password and
+# authenticates via duroxide-node's native Entra path; CMS + facts use
+# the PILOTSWARM_CMS_FACTS_DATABASE_URL above.
 DATABASE_URL=postgresql://placeholder:placeholder@placeholder:5432/placeholder?sslmode=require
 
 # SPC keys hash. Computed by deploy/scripts/lib/spc-keys-hash.mjs from

--- a/deploy/gitops/worker/overlays/default/.env
+++ b/deploy/gitops/worker/overlays/default/.env
@@ -43,9 +43,11 @@ PILOTSWARM_CMS_FACTS_DATABASE_URL=postgresql://placeholder@placeholder:5432/plac
 PILOTSWARM_DB_AAD_USER=placeholder
 # DATABASE_URL is config (not a KV secret) in the bicep-deploy flow. The
 # substituter composes it at deploy time from POSTGRES_FQDN + the bootstrap
-# admin password (deploy/services/base-infra/bicep/postgres.bicep). Used by
-# duroxide's PostgresProvider (no AAD token-callback hook upstream); CMS
-# + facts use PILOTSWARM_CMS_FACTS_DATABASE_URL above.
+# admin password (deploy/services/base-infra/bicep/postgres.bicep). Kept
+# available for the legacy deploy-aks.sh flow and as a fallback when MI
+# is not enabled. In MI mode the duroxide orchestration store ignores
+# any embedded password and authenticates via duroxide-node's native
+# Entra path; CMS + facts use PILOTSWARM_CMS_FACTS_DATABASE_URL above.
 DATABASE_URL=postgresql://placeholder:placeholder@placeholder:5432/placeholder?sslmode=require
 # SPC keys hash. Computed by deploy/scripts/lib/spc-keys-hash.mjs from
 # the worker SPC's projected key list. Read by the worker-replacements

--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -284,7 +284,7 @@ The bicep-deploy path enables MI mode by setting these in the overlay
 | `AZURE_STORAGE_ACCOUNT_URL=https://<acct>.blob.core.windows.net/` | Worker constructs `BlobServiceClient(accountUrl, DefaultAzureCredential)`. SAS generation throws `NotSupportedInManagedIdentityMode` — artifact downloads must proxy through the worker. |
 | `PILOTSWARM_CMS_FACTS_DATABASE_URL=postgresql://<aad-user>@<fqdn>:5432/<db>?sslmode=require` | Passwordless URL for CMS + facts pools. The factory installs an AAD token callback (`https://ossrdbms-aad.database.windows.net/.default`). |
 | `PILOTSWARM_DB_AAD_USER=<csi-uami-display-name>` | Postgres AAD admin role name = CSI UAMI display name. Used to build `aadUser` in the factory. |
-| `DATABASE_URL=postgresql://<bootstrap-pwd-user>:<pwd>@<fqdn>:5432/<db>` | **Still password-based.** Used only by duroxide, whose `JsPostgresProvider.connect()` has no token-callback hook. CMS+facts ignore it in MI mode. |
+| `DATABASE_URL=postgresql://<bootstrap-pwd-user>:<pwd>@<fqdn>:5432/<db>` | Password URL kept available for the legacy `scripts/deploy-aks.sh` flow and as a fallback when MI is not configured. In MI mode the duroxide store ignores any password in this URL and authenticates via duroxide-node's native Entra path (`PostgresProvider.connectWithSchemaAndEntra`, duroxide-node ≥ 0.1.25). |
 
 `deploy.mjs` composes `AZURE_STORAGE_ACCOUNT_URL` from the
 `BLOB_CONTAINER_ENDPOINT` Bicep output, and composes
@@ -303,19 +303,27 @@ The bicep-deploy path enables MI mode by setting these in the overlay
 Both reuse the same CSI UAMI federated to the worker's KSA, so a single
 identity covers KV → SPC, blob, and Postgres access.
 
-### Hybrid Postgres rationale
+### Postgres auth rationale
 
-Duroxide's `JsPostgresProvider.connect(databaseUrl)` only accepts a URL
-string and has no token-callback hook upstream. The deploy path takes
-the **hybrid** approach until a duroxide PR lands:
+In MI mode all three Postgres consumers — CMS, facts, and the duroxide
+orchestration store — authenticate to Azure Database for PostgreSQL
+Flexible Server via Microsoft Entra ID:
 
-- **CMS + facts** → AAD via `pg-pool-factory.ts` (`buildPgPoolConfig`)
-- **Duroxide store** → password URL (`DATABASE_URL`), bicep-managed,
-  rotated like any other bootstrap admin password
+- **CMS + facts** → AAD via `pg-pool-factory.ts` (`buildPgPoolConfig`),
+  using `DefaultAzureCredential` and pg's `password` callback.
+- **Duroxide store** → AAD via `duroxide-provider-factory.ts`
+  (`createDuroxidePostgresProvider`), which calls duroxide-node's
+  `PostgresProvider.connectWithSchemaAndEntra`. Duroxide resolves its
+  credential chain in Rust (WorkloadIdentity → ManagedIdentity →
+  DeveloperTools).
 
-Per `Duroxide Bugs` in `.github/copilot-instructions.md`, this is a
-deliberate, user-approved compromise — not a workaround that should
-spread elsewhere.
+`DATABASE_URL` (password URL) is kept alongside for the legacy
+`scripts/deploy-aks.sh` flow; in MI mode the duroxide store ignores any
+embedded password. Fully passwordless deployments may flip
+`passwordAuth: 'Disabled'` on the Bicep `postgres.bicep` module and
+drop the bootstrap admin password from Key Vault and the
+SecretProviderClass once their deploy path is on duroxide-node ≥ 0.1.25
+(pilotswarm-sdk ≥ 0.1.29).
 
 ## Model providers (LLM catalog)
 

--- a/deploy/scripts/lib/compose-env.mjs
+++ b/deploy/scripts/lib/compose-env.mjs
@@ -47,9 +47,12 @@ export function composeDerivedEnv(env) {
   // AAD URL for CMS + facts pools (pg-pool-factory.ts uses an AAD token
   // callback). The `user@` segment must match the AAD principal name
   // registered as a Postgres administrator (postgres.bicep
-  // `aadAdminPrincipalName` → POSTGRES_AAD_ADMIN_PRINCIPAL_NAME). Duroxide
-  // stays on the password URL (DATABASE_URL above) because its
-  // PostgresProvider has no token-callback hook upstream.
+  // `aadAdminPrincipalName` → POSTGRES_AAD_ADMIN_PRINCIPAL_NAME). The
+  // duroxide orchestration store also honours the MI switch via
+  // duroxide-node's native Entra path (PostgresProvider
+  // .connectWithSchemaAndEntra, available since duroxide-node 0.1.25);
+  // when PILOTSWARM_USE_MANAGED_IDENTITY=1 the worker reuses the same
+  // AAD user / passwordless URL for the duroxide store too.
   if (!env.PILOTSWARM_DB_AAD_USER && env.POSTGRES_AAD_ADMIN_PRINCIPAL_NAME) {
     env.PILOTSWARM_DB_AAD_USER = env.POSTGRES_AAD_ADMIN_PRINCIPAL_NAME;
   }

--- a/deploy/services/base-infra/bicep/postgres.bicep
+++ b/deploy/services/base-infra/bicep/postgres.bicep
@@ -85,10 +85,12 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2023-12-01-preview'
     version: postgresVersion
     administratorLogin: administratorLogin
     administratorLoginPassword: administratorPassword
-    // Hybrid auth: AAD enabled for CMS+facts pools (token callback);
-    // password kept enabled because duroxide's PostgresProvider only
-    // accepts a password URL — it has no token-callback hook. See
-    // packages/sdk/src/pg-pool-factory.ts and the Chunk C plan.
+    // Hybrid auth: AAD enabled for CMS+facts pools (token callback) and
+    // for the duroxide orchestration store (duroxide-node >= 0.1.25
+    // native Entra path). Password kept enabled by default so the
+    // legacy `scripts/deploy-aks.sh` flow and the bicep-bootstrap admin
+    // login still work; downstream MI-only deployers can flip
+    // `passwordAuth` to 'Disabled' for full passwordless cutover.
     authConfig: {
       activeDirectoryAuth: empty(aadAdminPrincipalId) ? 'Disabled' : 'Enabled'
       passwordAuth: 'Enabled'

--- a/package-lock.json
+++ b/package-lock.json
@@ -654,6 +654,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -671,6 +672,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -688,6 +690,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -705,6 +708,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -722,6 +726,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -739,6 +744,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -756,6 +762,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -773,6 +780,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -790,6 +798,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -807,6 +816,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -824,6 +834,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -841,6 +852,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -858,6 +870,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -875,6 +888,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -892,6 +906,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -909,6 +924,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -926,6 +942,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -943,6 +960,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -960,6 +978,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -977,6 +996,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -994,6 +1014,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1011,6 +1032,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1028,6 +1050,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1045,6 +1068,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1062,6 +1086,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1079,6 +1104,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2762,25 +2788,25 @@
       }
     },
     "node_modules/duroxide": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide/-/duroxide-0.1.25.tgz",
-      "integrity": "sha512-Ubwqx8hyLuBUMPuqHk+KgT8BY6M+3iIZonv2bt9dBY/iavmBp51L/Osiab5dcPli2WQB6G4q5Ou7+2FL0tf/Tg==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide/-/duroxide-0.1.26.tgz",
+      "integrity": "sha512-TsB7HXldBLRIkyK2XE/EeswsOv1oq1D8029Jw4T6zTbfxi4KE0cqRbDUApjmGjCZneM0fhUWRlpieAOyt1nxEg==",
       "license": "MIT",
       "engines": {
         "node": ">= 18"
       },
       "optionalDependencies": {
-        "duroxide-darwin-arm64": "0.1.25",
-        "duroxide-darwin-x64": "0.1.25",
-        "duroxide-linux-arm64-gnu": "0.1.25",
-        "duroxide-linux-x64-gnu": "0.1.25",
-        "duroxide-windows-x64": "0.1.25"
+        "duroxide-darwin-arm64": "0.1.26",
+        "duroxide-darwin-x64": "0.1.26",
+        "duroxide-linux-arm64-gnu": "0.1.26",
+        "duroxide-linux-x64-gnu": "0.1.26",
+        "duroxide-windows-x64": "0.1.26"
       }
     },
     "node_modules/duroxide-darwin-arm64": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide-darwin-arm64/-/duroxide-darwin-arm64-0.1.25.tgz",
-      "integrity": "sha512-sTfPGW4NuHKVlK7rVDgnycKe7y/KyISJjlbiW4ybDxUktKomoRXbb9q1YTL1CbFdV3daHE2PkWiMRwtAyBDYQA==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide-darwin-arm64/-/duroxide-darwin-arm64-0.1.26.tgz",
+      "integrity": "sha512-sOYLbr5hzzjjPJ30ihVyBaZiOU4izV0Fj8cfITiwlra+Hg8uOQvAxwRAPE0H2X7uaIQCWtBdVUFxJyZCD2dlQg==",
       "cpu": [
         "arm64"
       ],
@@ -2794,9 +2820,9 @@
       }
     },
     "node_modules/duroxide-darwin-x64": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide-darwin-x64/-/duroxide-darwin-x64-0.1.25.tgz",
-      "integrity": "sha512-MwIVrsiZMvnsqZrdKlO/v7PbGo3ATj/IVuzZRxfReBU/s4Kk1zFfi9fyH9WNVn8q1D8J7UuRXzEG5YsMyINOiw==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide-darwin-x64/-/duroxide-darwin-x64-0.1.26.tgz",
+      "integrity": "sha512-EUh+4IzbKQgc4Mi0VssQo+FX/zO44ufS8bNvlOIYi3BwId+ii32k4UaRZC/VSs+Qm5NzyYSLpMth++FZxUzQdw==",
       "cpu": [
         "x64"
       ],
@@ -2810,9 +2836,9 @@
       }
     },
     "node_modules/duroxide-linux-arm64-gnu": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide-linux-arm64-gnu/-/duroxide-linux-arm64-gnu-0.1.25.tgz",
-      "integrity": "sha512-KoC7+iD1yrEwHwY1cy+ylKv9TzISGcxnb8zB4Fy0w2A2SMSrfkZtcT7mb14BUM/Wnjh8NigzHeIcfzX2fEL/gQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide-linux-arm64-gnu/-/duroxide-linux-arm64-gnu-0.1.26.tgz",
+      "integrity": "sha512-O7Q6lQmoupU0fmfqtDtMhUAFGu9y5xmyedDhFDIhH6FoCrjHYmfS8KpiQLN4qWp0dCpc4wFMGL6H2lPVkFFK4w==",
       "cpu": [
         "arm64"
       ],
@@ -2826,9 +2852,9 @@
       }
     },
     "node_modules/duroxide-linux-x64-gnu": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide-linux-x64-gnu/-/duroxide-linux-x64-gnu-0.1.25.tgz",
-      "integrity": "sha512-SeT2BcSM41D/xDWZ4T4KGmE/kVKKWhbKW/s+kpbDA5PytoUwaavac2honJaeLTpsrR6pDWM1haU4rJSAvC7ESQ==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide-linux-x64-gnu/-/duroxide-linux-x64-gnu-0.1.26.tgz",
+      "integrity": "sha512-A7HvGANIfb5q+UvcnsbyQL02yiGFWxFkv1x65y00xzgvzD4i1f3kAguv7NY0U683QkJLTUzF33AIFy0hQZLJYA==",
       "cpu": [
         "x64"
       ],
@@ -2842,9 +2868,9 @@
       }
     },
     "node_modules/duroxide-windows-x64": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/duroxide-windows-x64/-/duroxide-windows-x64-0.1.25.tgz",
-      "integrity": "sha512-G+BurjbQm7To4kDVG3sIMPV7dS/KKei33x8xLLExxDTgTMBguIBGMq9O2BHVNnteixrSQq20w60NIiQaFqQy/Q==",
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/duroxide-windows-x64/-/duroxide-windows-x64-0.1.26.tgz",
+      "integrity": "sha512-1CRdnaMtwA4W5EF1R//UPmyj1USwvM+qgqzW+a4PRjW0uS3BYN8L4Ycu6BUkZuOBBEtZ7AcwEwv5wDilwptM8Q==",
       "cpu": [
         "x64"
       ],
@@ -5803,14 +5829,14 @@
     },
     "packages/sdk": {
       "name": "pilotswarm-sdk",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
         "@azure/storage-blob": "^12.31.0",
         "@github/copilot": "^1.0.36",
         "@github/copilot-sdk": "^0.3.0",
-        "duroxide": "^0.1.25",
+        "duroxide": "^0.1.26",
         "file-type": "^20.5.0",
         "pg": "^8.18.0"
       },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -65,7 +65,7 @@
     "@azure/storage-blob": "^12.31.0",
     "@github/copilot": "^1.0.36",
     "@github/copilot-sdk": "^0.3.0",
-    "duroxide": "^0.1.25",
+    "duroxide": "^0.1.26",
     "file-type": "^20.5.0",
     "pg": "^8.18.0"
   },

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilotswarm-sdk",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "A durable execution runtime for GitHub Copilot SDK agents. Crash recovery, durable timers, session dehydration, and multi-node scaling — powered by duroxide.",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -22,6 +22,7 @@ import type { SessionCatalogProvider, SessionEvent } from "./cms.js";
 import { PgSessionCatalogProvider } from "./cms.js";
 import type { FactStore } from "./facts-store.js";
 import { createFactStoreForUrl } from "./facts-store.js";
+import { createDuroxidePostgresProvider } from "./duroxide-provider-factory.js";
 import { deriveStatusFromCmsAndRuntime, shouldSyncCompletedStatus, shouldSyncFailedStatus } from "./session-status.js";
 
 // duroxide is CommonJS — use createRequire for ESM compatibility
@@ -404,10 +405,13 @@ export class PilotSwarmClient {
         const startedAt = Date.now();
         const trace = (message: string) => _trace(`[+${Date.now() - startedAt}ms] ${message}`);
 
-        // CMS + facts may use a passwordless URL (AAD/MI) while duroxide
-        // stays on the password URL. When `useManagedIdentity` is set the
-        // caller is expected to pass `cmsFactsDatabaseUrl` (a passwordless
-        // form). When unset (legacy / local), both pools reuse `store`.
+        // CMS + facts may use a separate URL when running with AAD/MI
+        // (passwordless URL whose `user@` segment is the federated UAMI's
+        // display name). Defaults to `store` for the legacy
+        // connection-string path. The duroxide orchestration store
+        // honours the same MI switch via duroxide-node's native Entra
+        // path; CMS/facts go through the pg-pool factory using
+        // `DefaultAzureCredential`.
         const cmsFactsUrl = this.config.cmsFactsDatabaseUrl ?? store;
         const useMi = this.config.useManagedIdentity ?? false;
         const aadUser = this.config.aadDbUser;
@@ -417,9 +421,14 @@ export class PilotSwarmClient {
         if (store === "sqlite::memory:") provider = SqliteProvider.inMemory();
         else if (store.startsWith("sqlite://")) provider = SqliteProvider.open(store);
         else if (store.startsWith("postgres://") || store.startsWith("postgresql://")) {
-            trace("[client] connectWithSchema start...");
-            provider = await PostgresProvider.connectWithSchema(store, this.config.duroxideSchema ?? DEFAULT_DUROXIDE_SCHEMA);
-            trace("[client] connectWithSchema done");
+            trace("[client] duroxide provider connect start...");
+            provider = await createDuroxidePostgresProvider(
+                PostgresProvider,
+                store,
+                this.config.duroxideSchema ?? DEFAULT_DUROXIDE_SCHEMA,
+                { useManagedIdentity: useMi, aadUser },
+            );
+            trace("[client] duroxide provider connect done");
         } else {
             throw new Error(`Unsupported store URL: ${store}`);
         }

--- a/packages/sdk/src/duroxide-provider-factory.ts
+++ b/packages/sdk/src/duroxide-provider-factory.ts
@@ -1,0 +1,73 @@
+/**
+ * Duroxide orchestration-store provider factory.
+ *
+ * Mirrors the MI feature switch used by `pg-pool-factory.ts` (CMS +
+ * facts), but routes through duroxide's own Postgres provider rather
+ * than node-pg. URL parsing and AAD user resolution are shared with
+ * pg-pool-factory so the two paths stay aligned.
+ *
+ * Legacy path (`useManagedIdentity: false`, the default):
+ *   `PostgresProvider.connectWithSchema(store, schema)` — unchanged
+ *   password-in-URL flow used by the legacy `deploy-aks.sh` script.
+ *
+ * MI path (`useManagedIdentity: true`):
+ *   `PostgresProvider.connectWithSchemaAndEntra(host, port, database,
+ *   user, schema)` — duroxide-native AAD path added in
+ *   duroxide-node@0.1.25. Duroxide resolves its credential chain in
+ *   Rust (WorkloadIdentity → ManagedIdentity → DeveloperTools) so we
+ *   do not pass a token callback here.
+ *
+ * @internal
+ */
+import { parsePostgresUrl, resolveAadPostgresUser } from "./pg-pool-factory.js";
+
+export interface DuroxideProviderFactoryOptions {
+    /** Opt into AAD token auth in duroxide. Defaults to `false`. */
+    useManagedIdentity?: boolean;
+    /** UAMI display name when the URL doesn't carry the AAD principal. */
+    aadUser?: string;
+}
+
+/**
+ * Minimal duroxide `PostgresProvider` shape this factory needs. Lets
+ * tests substitute a stub without dragging in the real native module.
+ */
+export interface DuroxidePostgresProviderModule {
+    connectWithSchema(connectionString: string, schema: string): Promise<unknown>;
+    connectWithSchemaAndEntra(
+        host: string,
+        port: number,
+        database: string,
+        user: string,
+        schema: string,
+        options?: unknown,
+    ): Promise<unknown>;
+}
+
+/**
+ * Build a duroxide `PostgresProvider` for the orchestration store,
+ * honouring the MI feature switch. Throws for non-Postgres URLs — the
+ * caller is responsible for routing sqlite stores elsewhere.
+ *
+ * @internal
+ */
+export async function createDuroxidePostgresProvider(
+    PostgresProvider: DuroxidePostgresProviderModule,
+    store: string,
+    schema: string,
+    opts: DuroxideProviderFactoryOptions = {},
+): Promise<unknown> {
+    if (!opts.useManagedIdentity) {
+        return PostgresProvider.connectWithSchema(store, schema);
+    }
+
+    const parsed = parsePostgresUrl(store);
+    const user = resolveAadPostgresUser(parsed, opts.aadUser);
+    return PostgresProvider.connectWithSchemaAndEntra(
+        parsed.host,
+        parsed.port,
+        parsed.database,
+        user,
+        schema,
+    );
+}

--- a/packages/sdk/src/management-client.ts
+++ b/packages/sdk/src/management-client.ts
@@ -38,6 +38,7 @@ import type {
 } from "./cms.js";
 import type { FactStore, FactsStatsRow } from "./facts-store.js";
 import { createFactStoreForUrl } from "./facts-store.js";
+import { createDuroxidePostgresProvider } from "./duroxide-provider-factory.js";
 import { SessionDumper } from "./session-dumper.js";
 import { loadModelProviders, type ModelProviderRegistry, type ModelDescriptor, type ReasoningEffort } from "./model-providers.js";
 import { deriveStatusFromCmsAndRuntime, shouldSyncCompletedStatus, shouldSyncFailedStatus } from "./session-status.js";
@@ -268,27 +269,32 @@ export class PilotSwarmManagementClient {
         const store = this.config.store;
         const _trace = this.config.traceWriter ?? (() => {});
 
+        // CMS + facts may use a separate URL when running with AAD/MI
+        // (passwordless URL whose `user@` segment is the federated UAMI's
+        // display name). Mirrors PilotSwarmClient.start(). The duroxide
+        // orchestration store honours the same MI switch via
+        // duroxide-node's native Entra path.
+        const cmsFactsUrl = this.config.cmsFactsDatabaseUrl ?? store;
+        const useMi = this.config.useManagedIdentity ?? false;
+        const aadUser = this.config.aadDbUser;
+
         // Create duroxide client
         let provider: any;
         if (store === "sqlite::memory:") provider = SqliteProvider.inMemory();
         else if (store.startsWith("sqlite://")) provider = SqliteProvider.open(store);
         else if (store.startsWith("postgres://") || store.startsWith("postgresql://")) {
-            _trace("[mgmt] connectWithSchema start...");
-            provider = await PostgresProvider.connectWithSchema(
+            _trace("[mgmt] duroxide provider connect start...");
+            provider = await createDuroxidePostgresProvider(
+                PostgresProvider,
                 store,
                 this.config.duroxideSchema ?? DEFAULT_DUROXIDE_SCHEMA,
+                { useManagedIdentity: useMi, aadUser },
             );
-            _trace("[mgmt] connectWithSchema done");
+            _trace("[mgmt] duroxide provider connect done");
         } else {
             throw new Error(`Unsupported store URL: ${store}`);
         }
         this._duroxideClient = new Client(provider);
-
-        // CMS + facts may use a passwordless URL (AAD/MI) while duroxide
-        // stays on the password URL. Mirrors PilotSwarmClient.start().
-        const cmsFactsUrl = this.config.cmsFactsDatabaseUrl ?? store;
-        const useMi = this.config.useManagedIdentity ?? false;
-        const aadUser = this.config.aadDbUser;
 
         // Create CMS catalog
         if (cmsFactsUrl.startsWith("postgres://") || cmsFactsUrl.startsWith("postgresql://")) {

--- a/packages/sdk/src/pg-pool-factory.ts
+++ b/packages/sdk/src/pg-pool-factory.ts
@@ -1,14 +1,14 @@
 /**
- * Pg pool factory — feature-switched between connection-string auth (the
- * legacy and only path until Chunk C) and Microsoft Entra (AAD) token auth
- * for the bicep-deploy flow on AKS with workload identity.
+ * Pg pool factory — feature-switched between connection-string auth and
+ * Microsoft Entra (AAD) token auth for the bicep-deploy flow on AKS with
+ * workload identity. Used by the CMS + facts pg.Pool paths.
  *
- * Chunk C scope: CMS + facts pools only. Duroxide's `PostgresProvider`
- * accepts a connection-string URL and has no token-callback hook, so it
- * keeps using the password URL (still bicep-managed, server-side AAD is
- * just enabled alongside password auth — see
- * `deploy/services/BaseInfra/bicep/postgres.bicep`). When duroxide gains
- * a token hook upstream we'll move it onto this factory too.
+ * The duroxide orchestration store has its own Entra path
+ * (`PostgresProvider.connectWithSchemaAndEntra`, available in
+ * duroxide-node >= 0.1.25) which uses duroxide's native credential chain
+ * in Rust rather than the JS `DefaultAzureCredential` used here; see
+ * `duroxide-provider-factory.ts`. URL parsing is shared between both
+ * paths via `parsePostgresUrl` / `resolveAadPostgresUser` below.
  *
  * @internal
  */
@@ -70,6 +70,77 @@ export interface PgPoolFactoryOptions {
 }
 
 /**
+ * Parsed components of a `postgres://` / `postgresql://` connection
+ * string in the shape both the pg.Pool factory and the duroxide
+ * provider factory need. Centralizes the sslmode-stripping and
+ * default-port/database behaviour so the two paths stay aligned.
+ *
+ * @internal
+ */
+export interface ParsedPgUrl {
+    host: string;
+    /** Defaults to 5432 when the URL omits a port. */
+    port: number;
+    /** Defaults to `postgres` when the URL has no pathname. */
+    database: string;
+    /** Decoded URL `user@` segment, or empty string when absent. */
+    urlUsername: string;
+    /** True when sslmode is require/prefer/verify-ca/verify-full. */
+    needsSsl: boolean;
+    /** Connection string with `sslmode` stripped from the query. */
+    sanitizedConnectionString: string;
+}
+
+/**
+ * Parse a Postgres connection string into the parts both the pg.Pool
+ * factory (for CMS/facts) and the duroxide provider factory need.
+ *
+ * @internal
+ */
+export function parsePostgresUrl(connectionString: string): ParsedPgUrl {
+    const url = new URL(connectionString);
+
+    // pg v8 treats sslmode=require as verify-full, which rejects Azure /
+    // self-signed certs. Strip sslmode from URL and control SSL via
+    // config object — same workaround the existing cms.ts / facts-store.ts
+    // pools have used since well before the MI work.
+    const needsSsl = ["require", "prefer", "verify-ca", "verify-full"]
+        .includes(url.searchParams.get("sslmode") ?? "");
+    url.searchParams.delete("sslmode");
+
+    return {
+        host: url.hostname,
+        port: url.port ? Number(url.port) : 5432,
+        database: decodeURIComponent(url.pathname.replace(/^\//, "")) || "postgres",
+        urlUsername: url.username ? decodeURIComponent(url.username) : "",
+        needsSsl,
+        sanitizedConnectionString: url.toString(),
+    };
+}
+
+/**
+ * Resolve the Postgres role to use in managed-identity mode. Prefers
+ * the caller-provided `aadUser` (typically the federated UAMI display
+ * name), falling back to the URL's `user@` segment.
+ *
+ * Throws when neither is set so misconfigurations fail loudly at
+ * startup rather than producing cryptic auth errors at first query.
+ *
+ * @internal
+ */
+export function resolveAadPostgresUser(parsed: ParsedPgUrl, aadUser?: string): string {
+    const user = aadUser ?? parsed.urlUsername;
+    if (!user) {
+        throw new Error(
+            "managed-identity mode requires a Postgres user " +
+            "(either as the URL `user@` segment or via opts.aadUser). The user " +
+            "must match the AAD principal name registered as a Postgres administrator.",
+        );
+    }
+    return user;
+}
+
+/**
  * Build a `pg.PoolConfig` honouring the MI feature switch.
  *
  * Implementation note: pg accepts `password` as either `string` or a
@@ -81,22 +152,13 @@ export interface PgPoolFactoryOptions {
  * @internal
  */
 export function buildPgPoolConfig(opts: PgPoolFactoryOptions): PoolConfig {
-    const url = new URL(opts.connectionString);
-
-    // pg v8 treats sslmode=require as verify-full, which rejects Azure /
-    // self-signed certs. Strip sslmode from URL and control SSL via
-    // config object — same workaround the existing cms.ts / facts-store.ts
-    // pools have used since well before Chunk C.
-    const needsSsl = ["require", "prefer", "verify-ca", "verify-full"]
-        .includes(url.searchParams.get("sslmode") ?? "");
-    url.searchParams.delete("sslmode");
-
-    const sslConfig = needsSsl ? { ssl: { rejectUnauthorized: false } } : {};
+    const parsed = parsePostgresUrl(opts.connectionString);
+    const sslConfig = parsed.needsSsl ? { ssl: { rejectUnauthorized: false } } : {};
     const max = opts.max ?? 3;
 
     if (!opts.useManagedIdentity) {
         return {
-            connectionString: url.toString(),
+            connectionString: parsed.sanitizedConnectionString,
             max,
             ...sslConfig,
         };
@@ -107,25 +169,13 @@ export function buildPgPoolConfig(opts: PgPoolFactoryOptions): PoolConfig {
     // because pg's `password` callback only takes effect when there is
     // no password embedded in the connectionString — pg-protocol picks
     // up an empty URL password before consulting the callback.
-    const port = url.port ? Number(url.port) : 5432;
-    const database = decodeURIComponent(url.pathname.replace(/^\//, "")) || "postgres";
-    const user = opts.aadUser
-        ?? (url.username ? decodeURIComponent(url.username) : "");
-
-    if (!user) {
-        throw new Error(
-            "buildPgPoolConfig: managed-identity mode requires a Postgres user " +
-            "(either as the URL `user@` segment or via opts.aadUser). The user " +
-            "must match the AAD principal name registered as a Postgres administrator.",
-        );
-    }
-
+    const user = resolveAadPostgresUser(parsed, opts.aadUser);
     const credential = getCredential();
 
     return {
-        host: url.hostname,
-        port,
-        database,
+        host: parsed.host,
+        port: parsed.port,
+        database: parsed.database,
         user,
         password: async () => {
             const token = await credential.getToken(POSTGRES_AAD_SCOPE);

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -418,9 +418,11 @@ export interface PilotSwarmWorkerOptions {
      *
      * Also routes CMS + facts pools through the AAD pg-pool factory:
      * tokens are minted via `DefaultAzureCredential` and pg invokes the
-     * `password` callback on every new physical connection. Duroxide's
-     * orchestration store still uses the password URL in `store` because
-     * its `PostgresProvider` has no token-callback hook upstream.
+     * `password` callback on every new physical connection. The duroxide
+     * orchestration store goes through duroxide-node's native Entra path
+     * (`PostgresProvider.connectWithSchemaAndEntra`, available since
+     * duroxide-node 0.1.25), which resolves credentials in Rust via its
+     * own chain (WorkloadIdentity → ManagedIdentity → DeveloperTools).
      */
     useManagedIdentity?: boolean;
     /**

--- a/packages/sdk/src/worker.ts
+++ b/packages/sdk/src/worker.ts
@@ -1,3 +1,4 @@
+import { createDuroxidePostgresProvider } from "./duroxide-provider-factory.js";
 import { SessionManager } from "./session-manager.js";
 import { SessionBlobStore, createSessionBlobStore } from "./blob-store.js";
 import { FilesystemArtifactStore, FilesystemSessionStore, type ArtifactStore, type SessionStateStore } from "./session-store.js";
@@ -350,12 +351,14 @@ export class PilotSwarmWorker {
 
         this._provider = await this._createProvider();
 
-        // Initialize CMS catalog and facts store
+        // Initialize CMS catalog and facts store.
         // CMS + facts can use a separate URL when running with AAD/MI
         // (passwordless URL whose `user@` segment is the federated UAMI's
         // display name). Defaults to `store` for the legacy
-        // connection-string path. Duroxide's PostgresProvider stays on
-        // `store` because it has no AAD token-callback hook upstream.
+        // connection-string path. The duroxide orchestration store
+        // (created above in `_createProvider`) honours the same MI
+        // switch via duroxide-node's native Entra path; CMS/facts go
+        // through the pg-pool factory using `DefaultAzureCredential`.
         const cmsFactsUrl = this.config.cmsFactsDatabaseUrl ?? store;
         const useMi = this.config.useManagedIdentity ?? false;
         const aadUser = this.config.aadDbUser;
@@ -901,7 +904,15 @@ export class PilotSwarmWorker {
         if (store === "sqlite::memory:") return SqliteProvider.inMemory();
         if (store.startsWith("sqlite://")) return SqliteProvider.open(store);
         if (store.startsWith("postgres://") || store.startsWith("postgresql://")) {
-            return PostgresProvider.connectWithSchema(store, this.config.duroxideSchema ?? DEFAULT_DUROXIDE_SCHEMA);
+            return createDuroxidePostgresProvider(
+                PostgresProvider,
+                store,
+                this.config.duroxideSchema ?? DEFAULT_DUROXIDE_SCHEMA,
+                {
+                    useManagedIdentity: this.config.useManagedIdentity ?? false,
+                    aadUser: this.config.aadDbUser,
+                },
+            );
         }
         throw new Error(`Unsupported store URL: ${store}`);
     }

--- a/packages/sdk/test/local/duroxide-provider-factory.test.js
+++ b/packages/sdk/test/local/duroxide-provider-factory.test.js
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for the duroxide orchestration-store provider factory.
+ *
+ * Pure logic — no live database needed. Mocks the duroxide
+ * `PostgresProvider` shape so the test stays in sync with whatever
+ * arguments worker.ts passes through.
+ */
+import { describe, it, expect } from "vitest";
+import { createDuroxidePostgresProvider } from "../../src/duroxide-provider-factory.ts";
+
+function makeMockProvider() {
+    const calls = { connectWithSchema: [], connectWithSchemaAndEntra: [] };
+    return {
+        calls,
+        connectWithSchema: async (...args) => {
+            calls.connectWithSchema.push(args);
+            return { _kind: "legacy" };
+        },
+        connectWithSchemaAndEntra: async (...args) => {
+            calls.connectWithSchemaAndEntra.push(args);
+            return { _kind: "entra" };
+        },
+    };
+}
+
+describe("createDuroxidePostgresProvider", () => {
+    it("legacy: routes to connectWithSchema with the original store URL", async () => {
+        const mock = makeMockProvider();
+        const result = await createDuroxidePostgresProvider(
+            mock,
+            "postgresql://u:p@h:5432/db?sslmode=require",
+            "duroxide",
+        );
+        expect(result).toEqual({ _kind: "legacy" });
+        expect(mock.calls.connectWithSchemaAndEntra).toHaveLength(0);
+        expect(mock.calls.connectWithSchema).toEqual([
+            ["postgresql://u:p@h:5432/db?sslmode=require", "duroxide"],
+        ]);
+    });
+
+    it("legacy: explicit useManagedIdentity:false also takes the password path", async () => {
+        const mock = makeMockProvider();
+        await createDuroxidePostgresProvider(
+            mock,
+            "postgres://u:p@h/db",
+            "duroxide",
+            { useManagedIdentity: false, aadUser: "ignored" },
+        );
+        expect(mock.calls.connectWithSchema).toHaveLength(1);
+        expect(mock.calls.connectWithSchemaAndEntra).toHaveLength(0);
+    });
+
+    it("MI: routes to connectWithSchemaAndEntra with parsed host/port/database and aadUser", async () => {
+        const mock = makeMockProvider();
+        const result = await createDuroxidePostgresProvider(
+            mock,
+            "postgresql://ignored-user:ignored-pwd@my-pg.postgres.database.azure.com:5432/pilotswarm?sslmode=require",
+            "duroxide",
+            { useManagedIdentity: true, aadUser: "uami-display-name" },
+        );
+        expect(result).toEqual({ _kind: "entra" });
+        expect(mock.calls.connectWithSchema).toHaveLength(0);
+        expect(mock.calls.connectWithSchemaAndEntra).toEqual([
+            [
+                "my-pg.postgres.database.azure.com",
+                5432,
+                "pilotswarm",
+                "uami-display-name",
+                "duroxide",
+            ],
+        ]);
+    });
+
+    it("MI: falls back to the URL user@ segment when aadUser is omitted", async () => {
+        const mock = makeMockProvider();
+        await createDuroxidePostgresProvider(
+            mock,
+            "postgresql://uami-from-url@h:5432/db?sslmode=require",
+            "duroxide",
+            { useManagedIdentity: true },
+        );
+        expect(mock.calls.connectWithSchemaAndEntra[0][3]).toBe("uami-from-url");
+    });
+
+    it("MI: defaults port to 5432 and database to 'postgres' when URL omits them", async () => {
+        const mock = makeMockProvider();
+        await createDuroxidePostgresProvider(
+            mock,
+            "postgresql://uami@h",
+            "duroxide",
+            { useManagedIdentity: true },
+        );
+        const [host, port, database, user, schema] = mock.calls.connectWithSchemaAndEntra[0];
+        expect(host).toBe("h");
+        expect(port).toBe(5432);
+        expect(database).toBe("postgres");
+        expect(user).toBe("uami");
+        expect(schema).toBe("duroxide");
+    });
+
+    it("MI: throws when neither aadUser nor URL user is provided", async () => {
+        const mock = makeMockProvider();
+        await expect(
+            createDuroxidePostgresProvider(
+                mock,
+                "postgresql://h:5432/db",
+                "duroxide",
+                { useManagedIdentity: true },
+            ),
+        ).rejects.toThrow(/managed-identity mode requires a Postgres user/);
+        expect(mock.calls.connectWithSchemaAndEntra).toHaveLength(0);
+        expect(mock.calls.connectWithSchema).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary

When `useManagedIdentity: true`, the worker, client, and management client now route the duroxide Postgres store through `PostgresProvider.connectWithSchemaAndEntra` (added in duroxide-node 0.1.25) instead of `connectWithSchema`. CMS, facts, **and** the orchestration store all authenticate via Microsoft Entra ID — closing the last gap that forced deployments to keep a password URL just for duroxide.

The legacy password-in-URL path (`useManagedIdentity` unset or `false`) is **unchanged**, so the existing `scripts/deploy-aks.sh` flow continues to work without changes.

## Why

duroxide-node 0.1.25 (already declared in `packages/sdk/package.json` since 0.1.28) added native Entra constructors that authenticate via duroxide's own Rust credential chain (WorkloadIdentity → ManagedIdentity → DeveloperTools). The SDK was already wired for MI on the CMS + facts `pg.Pool` paths, but the duroxide orchestration store was still calling `connectWithSchema(passwordUrl, schema)`. Stale comments at `worker.ts:354-358`, `pg-pool-factory.ts:6-11`, and various deploy docs still claimed duroxide had no token-callback hook upstream — no longer true.

This unblocks **Phase 8** of microsoft/waldemort PR #7: downstream can now bump `pilotswarm-sdk`, drop the password `store:` arg, flip `passwordAuth: 'Disabled'` on the Bicep postgres module, and remove `postgres-admin-password` from Key Vault + the SecretProviderClass YAMLs.

## Changes

**Code:**
- `pg-pool-factory.ts` — extracted `parsePostgresUrl()` + `resolveAadPostgresUser()` so the orchestration path and the CMS/facts path share sslmode-stripping and user resolution.
- `duroxide-provider-factory.ts` *(new)* — `createDuroxidePostgresProvider()` routes to `connectWithSchema` (legacy) or `connectWithSchemaAndEntra` (MI). Takes the duroxide module as a parameter for a clean test seam.
- `worker.ts`, `client.ts`, `management-client.ts` — all three duroxide-client construction sites delegate to the factory.
- `types.ts` — JSDoc on `useManagedIdentity` updated.

**Tests:**
- `duroxide-provider-factory.test.js` *(new, 6 cases)* — legacy routing, explicit `useManagedIdentity: false`, MI with explicit `aadUser`, MI fallback to URL `user@`, MI default port/db, MI missing-user error.
- Existing `pg-pool-factory.test.js` (16 cases) unchanged and still passes.

**Docs:** Updated `README.md`, `CHANGELOG.md`, `deploy/scripts/README.md`, `deploy/services/base-infra/bicep/postgres.bicep`, `deploy/scripts/lib/compose-env.mjs`, `deploy/envs/template.env`, worker overlay `.env`, and 3 portal overlay `.env` files to reflect the unified Entra story.

**Release:** `packages/sdk/package.json` → `0.1.29`.

## Backward compatibility

| `useManagedIdentity` | Behaviour |
|---|---|
| unset / `false` (default) | `PostgresProvider.connectWithSchema(store, schema)` — identical to today. |
| `true` | `PostgresProvider.connectWithSchemaAndEntra(host, port, database, user, schema)` with user resolved as `aadDbUser ?? URL.username`. |

## Acceptance criteria

- [x] `_createProvider()` (and equivalents in client/management-client) branches on `useManagedIdentity`; legacy path unchanged.
- [x] URL parsing shared with the CMS/facts path — no duplication.
- [x] Stale "no token-callback hook upstream" comments updated.
- [x] Unit test mocks the duroxide module and asserts the right method is called with the right parsed args.
- [x] `pilotswarm-sdk` bumped to 0.1.29 with a CHANGELOG entry.
- [x] `npm run build` + `npm run lint` + 22/22 unit tests pass.

Live integration suites (`./scripts/run-tests.sh`) need Postgres + GitHub token and were not run in this session — recommend a reviewer or CI cover those before merge.
