### PR TITLE
chore(deploy): rename generated local env file to .env for editor highlighting

### DIFF
--- a/deploy/scripts/README.md
+++ b/deploy/scripts/README.md
@@ -30,7 +30,7 @@ needs, so `--steps bicep` works without `oras` / `docker` installed.
 There are two ways to point this script at a target subscription / cluster:
 
 Every deploy targets a personal local env at
-`deploy/envs/local/<name>/env`, scaffolded by `npm run deploy:new-env`
+`deploy/envs/local/<name>/.env`, scaffolded by `npm run deploy:new-env`
 from `deploy/envs/template.env`. The local file is standalone — no
 runtime cascade — so editing the template never retroactively changes
 existing envs.
@@ -134,7 +134,7 @@ Flags:
 | `build` | `docker build` the service image and `docker save` to a tarball under `deploy/.tmp/<svc>-<env>/`. | worker, portal |
 | `push` | `oras cp` the tarball into the per-region ACR (no Docker daemon push). | worker, portal |
 | `bicep` | Render `deploy/services/<Module>/bicep/<Module>.params.template.json` with `${VAR}` substitution from the env map, then `az deployment {sub|group} create`. Captures Bicep outputs back into the env map for downstream steps. | per-service module list |
-| `seed-secrets` | Read seedable secrets (`GITHUB_TOKEN` + `ANTHROPIC_API_KEY`) from the loaded env map (set by `new-env` in `deploy/envs/local/<name>/env`), validate they are non-empty, and `az keyvault secret set` each into the env's KV. SPC mounts them into the worker pod. See [Secrets & identity](#secrets--identity-bicep-deploy-path-only). | baseinfra |
+| `seed-secrets` | Read seedable secrets (`GITHUB_TOKEN` + `ANTHROPIC_API_KEY`) from the loaded env map (set by `new-env` in `deploy/envs/local/<name>/.env`), validate they are non-empty, and `az keyvault secret set` each into the env's KV. SPC mounts them into the worker pod. See [Secrets & identity](#secrets--identity-bicep-deploy-path-only). | baseinfra |
 | `manifests` | Substitute the overlay `.env` using the env map, stage the rendered `gitops/<svc>/` tree under `deploy/.tmp/<svc>-<env>/`, then `az storage blob upload-batch` the **unrendered** Kustomize tree to the Flux Storage Bucket. Flux reconciles the cluster from there. Worker / cert-manager / cert-manager-issuers each use a single `overlays/default` overlay (per-env values flow in via the staged `.env`); Portal overlays are keyed by `${EDGE_MODE}-${TLS_SOURCE}` (`overlays/afd-letsencrypt`, `overlays/afd-akv`, `overlays/private-akv` — `akv-selfsigned` shares the `private-akv` overlay). | worker, portal |
 | `rollout` | `flux reconcile kustomization <svc>-<svc> -n flux-system --with-source` (forces the Bucket source to re-pull the just-uploaded blobs and the Kustomization to apply that revision), then `kubectl rollout status deployment/<svc>` in `NAMESPACE`, then verifies live `image` ends with the expected tag. | worker, portal |
 
@@ -144,7 +144,7 @@ out).
 
 ## Env-file schema
 
-Every deploy targets a personal local env at `deploy/envs/local/<name>/env`
+Every deploy targets a personal local env at `deploy/envs/local/<name>/.env`
 (the entire `local/` directory is gitignored). Local env files are
 **standalone** — `deploy.mjs` reads them directly with no runtime cascade
 onto a shared base file.
@@ -152,7 +152,7 @@ onto a shared base file.
 `deploy/envs/template.env` is a checked-in template consumed only by the
 scaffolder (`npm run deploy:new-env`): it copies the template, substitutes
 deployment-target keys, prompts for per-stamp secrets, and writes the
-complete file under `local/<name>/env`. Subsequent edits to `template.env`
+complete file under `local/<name>/.env`. Subsequent edits to `template.env`
 affect only newly-scaffolded envs — never existing ones.
 
 `dev` and `prod` are reserved labels used by the enterprise path for ServiceGroup
@@ -192,7 +192,7 @@ placeholder" error directing you to run a prior `--steps bicep`.
 
 | | Enterprise path | OSS path |
 |---|---|---|
-| Source | `*.Configuration.json` per service | `deploy/envs/local/<name>/env` (standalone, scaffolded from `deploy/envs/template.env`) |
+| Source | `*.Configuration.json` per service | `deploy/envs/local/<name>/.env` (standalone, scaffolded from `deploy/envs/template.env`) |
 | Scope binding | the enterprise orchestrator injects subscription / region / IDs into the parameters JSON | `deploy/scripts/lib/common.mjs` resolves env file → JS Map |
 | `.env` substitution | the enterprise param-substitution helper rewrites overlay `.env` from JSON params | `deploy/scripts/lib/substitute-env.mjs` rewrites overlay `.env` from the env map |
 | Per-service identity | Per-service scope binding | Shared `csiIdentity` UAMI clientId cascades from BaseInfra Bicep output → both worker and portal overlays |
@@ -252,7 +252,7 @@ runtime cannot bootstrap on its own.
 ### Per-env secrets file
 
 `npm run deploy:new-env` prompts for the two seedable secrets and appends
-them to `deploy/envs/local/<name>/env` (gitignored — the entire
+them to `deploy/envs/local/<name>/.env` (gitignored — the entire
 `deploy/envs/local/` directory is excluded by
 `deploy/envs/.gitignore`). Required keys:
 

--- a/deploy/scripts/lib/common.mjs
+++ b/deploy/scripts/lib/common.mjs
@@ -55,7 +55,7 @@ export function parseEnvFile(path) {
 // ───────────────────────── Env name policy ─────────────────────────
 //
 // Every deploy targets a personal/local env at
-// `deploy/envs/local/<name>/env`. Local env files are STANDALONE: they
+// `deploy/envs/local/<name>/.env`. Local env files are STANDALONE: they
 // are seeded from `deploy/envs/template.env` at scaffold time
 // (deploy/scripts/new-env.mjs) and from that point on are a complete,
 // frozen record of the deployment target. There is NO runtime cascade
@@ -90,12 +90,12 @@ export function validateLocalEnvName(name) {
 }
 
 // Resolve the env file path for an env name. Always
-// `deploy/envs/local/<name>/env` — there are no canonical OSS env files
+// `deploy/envs/local/<name>/.env` — there are no canonical OSS env files
 // to deploy from anymore. The template at `deploy/envs/template.env` is
 // only consumed by the scaffolder (new-env.mjs).
 export function envFilePath(envName) {
   validateLocalEnvName(envName);
-  return join(REPO_ROOT, "deploy", "envs", "local", envName, "env");
+  return join(REPO_ROOT, "deploy", "envs", "local", envName, ".env");
 }
 
 // Path to the scaffolder template. Read by new-env.mjs at scaffold time.
@@ -104,7 +104,7 @@ export function templateEnvPath() {
 }
 
 // Load env map for a given local env name. Reads
-// `deploy/envs/local/<name>/env` standalone — no cascade onto the
+// `deploy/envs/local/<name>/.env` standalone — no cascade onto the
 // template (that file is only used at scaffold time).
 //
 // process.env values override file values key-by-key (so a contributor can
@@ -278,7 +278,7 @@ export function assertCli(name, hint, versionArgs = ["--version"]) {
 export function assertSubscription(expected) {
   if (!expected) {
     throw new Error(
-      "SUBSCRIPTION_ID is empty in the env map. Set it in your local env file (deploy/envs/local/<env>/env).",
+      "SUBSCRIPTION_ID is empty in the env map. Set it in your local env file (deploy/envs/local/<env>/.env).",
     );
   }
   const r = run("az", ["account", "show", "--query", "id", "-o", "tsv"], { capture: true });

--- a/deploy/scripts/lib/portal-config.mjs
+++ b/deploy/scripts/lib/portal-config.mjs
@@ -2,7 +2,7 @@
 // auth/authz behavior at runtime.
 //
 // These keys flow through the same generic env path as every other deploy
-// value: prompted by new-env, written into deploy/envs/local/<env>/env,
+// value: prompted by new-env, written into deploy/envs/local/<env>/.env,
 // merged by loadEnv into the in-memory env map, substituted into the
 // portal overlay .env by substitute-env.mjs, and projected into the pod
 // via the overlay-generated `portal-env` ConfigMap (envFrom configMapRef).

--- a/deploy/scripts/lib/publish-manifests.mjs
+++ b/deploy/scripts/lib/publish-manifests.mjs
@@ -25,7 +25,7 @@ export async function publishManifests({ service, envName, env, stagedServiceRoo
   if (!account) {
     throw new Error(
       "DEPLOYMENT_STORAGE_ACCOUNT_NAME must be set " +
-        "(seed in deploy/envs/local/<env>/env or run --steps bicep first).",
+        "(seed in deploy/envs/local/<env>/.env or run --steps bicep first).",
     );
   }
   // Container name is derived from the service name, not from

--- a/deploy/scripts/lib/push-image.mjs
+++ b/deploy/scripts/lib/push-image.mjs
@@ -29,7 +29,7 @@ export async function pushImage({ service, envName, imageTag, env, stagingDir: s
     throw new Error(
       "ACR_NAME and ACR_LOGIN_SERVER must be set in the env map.\n" +
         "Either run --steps bicep first (BaseInfra outputs populate them), or seed them\n" +
-        "in deploy/envs/local/<env>/env (FR-021).",
+        "in deploy/envs/local/<env>/.env (FR-021).",
     );
   }
 

--- a/deploy/scripts/lib/render-params.mjs
+++ b/deploy/scripts/lib/render-params.mjs
@@ -39,7 +39,7 @@ export function renderParams({ module, templatePath, envMap, outDir }) {
     const list = [...missing].sort().join(", ");
     throw new Error(
       `Bicep params template ${templatePath} has unresolved placeholders: ${list}. ` +
-        `Set them in deploy/envs/local/<env>/env and re-run.`,
+        `Set them in deploy/envs/local/<env>/.env and re-run.`,
     );
   }
 

--- a/deploy/scripts/lib/seed-secrets.mjs
+++ b/deploy/scripts/lib/seed-secrets.mjs
@@ -1,13 +1,13 @@
 // Seed-secrets stage for the OSS Node deploy orchestrator.
 //
 // Reads the already-merged env map (deploy/envs/<base>.env +
-// deploy/envs/local/<env>/env, with process.env overrides) and writes the
+// deploy/envs/local/<env>/.env, with process.env overrides) and writes the
 // human-only secrets into the per-stamp Key Vault via
 // `az keyvault secret set`. Idempotent: re-running just overwrites.
 //
 // What lives in the env map: see deploy/scripts/lib/common.mjs::loadEnv.
 // new-env.mjs interactively prompts for the required secrets and writes
-// them into deploy/envs/local/<env>/env (gitignored). There is no separate
+// them into deploy/envs/local/<env>/.env (gitignored). There is no separate
 // secrets.env file.
 //
 // Secret-name mapping is mechanical:
@@ -127,7 +127,7 @@ export async function seedSecrets({ envName, env }) {
     throw new Error(
       `seed-secrets: required key(s) missing or empty for env '${envName}': ${missingRequired.join(", ")}\n` +
       `These are populated by new-env. Run \`npm run deploy:new-env -- ${envName} --force\` to be re-prompted, ` +
-      `or edit deploy/envs/local/${envName}/env directly and re-run: ` +
+      `or edit deploy/envs/local/${envName}/.env directly and re-run: ` +
       `npm run deploy -- base-infra ${envName} --steps seed-secrets`,
     );
   }

--- a/deploy/scripts/lib/substitute-env.mjs
+++ b/deploy/scripts/lib/substitute-env.mjs
@@ -49,7 +49,7 @@ export function substituteOverlayEnv({ srcPath, dstPath, envMap }) {
     const list = [...unresolved].sort().join(", ");
     throw new Error(
       `Unresolved overlay .env keys in ${srcPath}: ${list}. ` +
-        `Set them in deploy/envs/local/<env>/env, or run a prior ` +
+        `Set them in deploy/envs/local/<env>/.env, or run a prior ` +
         `--steps bicep so FR-022 alias map populates them.`,
     );
   }

--- a/deploy/scripts/new-env.mjs
+++ b/deploy/scripts/new-env.mjs
@@ -7,7 +7,7 @@
 //
 // (Equivalent direct invocation: `node deploy/scripts/new-env.mjs ...`)
 //
-// Creates `deploy/envs/local/<name>/env` by copying `deploy/envs/template.env`
+// Creates `deploy/envs/local/<name>/.env` by copying `deploy/envs/template.env`
 // and substituting deployment-target keys using the same naming patterns
 // The enterprise path uses (the enterprise deployment manifests):
 //
@@ -445,7 +445,7 @@ function usage() {
   const lines = [
     "Usage: npm run deploy:new-env -- [<name>] [options]",
     "",
-    "Creates a personal local env at deploy/envs/local/<name>/env.",
+    "Creates a personal local env at deploy/envs/local/<name>/.env.",
     "<name> must match /^[a-z][a-z0-9]{0,11}$/ and not be a reserved name (dev, prod).",
     "Any flag not provided is prompted for interactively.",
     "",

--- a/deploy/scripts/test/local-env.test.mjs
+++ b/deploy/scripts/test/local-env.test.mjs
@@ -21,7 +21,7 @@ const LOCAL_DIR = join(ENV_DIR, "local");
 
 // Use a deterministic test name; clean up before/after.
 const TEST_NAME = "tstenv";
-const TEST_FILE = join(LOCAL_DIR, TEST_NAME, "env");
+const TEST_FILE = join(LOCAL_DIR, TEST_NAME, ".env");
 
 function cleanup() {
   const dir = join(LOCAL_DIR, TEST_NAME);
@@ -46,8 +46,8 @@ test("validateLocalEnvName rejects reserved names", () => {
   }
 });
 
-test("envFilePath resolves local names to deploy/envs/local/<name>/env", () => {
-  assert.equal(envFilePath("foo"), join(ENV_DIR, "local", "foo", "env"));
+test("envFilePath resolves local names to deploy/envs/local/<name>/.env", () => {
+  assert.equal(envFilePath("foo"), join(ENV_DIR, "local", "foo", ".env"));
 });
 
 test("envFilePath rejects reserved names", () => {

--- a/deploy/scripts/test/new-env.test.mjs
+++ b/deploy/scripts/test/new-env.test.mjs
@@ -14,7 +14,7 @@ import { REPO_ROOT } from "../lib/common.mjs";
 const SCRIPT = join(REPO_ROOT, "deploy", "scripts", "new-env.mjs");
 const LOCAL_DIR = join(REPO_ROOT, "deploy", "envs", "local");
 const TEST_NAME = "scafftst";
-const TEST_FILE = join(LOCAL_DIR, TEST_NAME, "env");
+const TEST_FILE = join(LOCAL_DIR, TEST_NAME, ".env");
 
 function cleanup() {
   const d = join(LOCAL_DIR, TEST_NAME);
@@ -73,7 +73,7 @@ test("renderLocalEnv produces expected substitutions", () => {
   assert.match(out, /^TLS_SOURCE=letsencrypt$/m);
 });
 
-test("scaffolder creates local/<name>/env (happy path)", () => {
+test("scaffolder creates local/<name>/.env (happy path)", () => {
   cleanup();
   try {
     const r = runScript(FULL_ARGS());


### PR DESCRIPTION
envFilePath now returns `deploy/envs/local/<name>/.env` (with a leading dot) so VS Code and other editors auto-detect dotenv syntax highlighting.

All docs, error messages, and tests updated accordingly. No behavior change beyond the filename.