### PR TITLE
[Entra App-Roles Modernization] Planning: tracking proposal for portal auth config reloader

### DIFF
--- a/docs/proposals/portal-auth-config-reloader.md
+++ b/docs/proposals/portal-auth-config-reloader.md
@@ -1,0 +1,85 @@
+# Portal Auth Config Reloader
+
+## Summary
+
+Add a config-reloader pattern to the portal authorization layer so that changes
+to `PORTAL_AUTHZ_*` env vars (group allowlists, role-name lists, default role,
+allow-unauthenticated, etc.) can take effect without restarting the portal
+process or pod. Today every change to these env vars requires a pod restart
+because `getProviderBundle()` caches the authorization policy for the process
+lifetime with no invalidation path.
+
+## Motivation
+
+The portal's auth bootstrap caches the resolved provider bundle (provider
+config + authorization policy) at module level on first call and reuses it
+forever:
+
+```js
+// packages/portal/auth/index.js
+let cachedBundle = null;
+export function getProviderBundle(env = process.env) {
+  if (cachedBundle) return cachedBundle;
+  // ... build provider + policy from env ...
+  cachedBundle = { provider, authorizationPolicy };
+  return cachedBundle;
+}
+```
+
+This was acceptable when the only knob was `PORTAL_AUTHZ_ADMIN_GROUPS` /
+`PORTAL_AUTHZ_USER_GROUPS` — small, well-known, infrequently changed. With the
+**Entra App-Roles Modernization** feature
+(`.paw/work/entra-app-roles-modernization/`, `docs/portal-entra-app-roles.md`)
+the surface grows:
+
+- `PORTAL_AUTHZ_ENTRA_ADMIN_ROLE_NAMES`
+- `PORTAL_AUTHZ_ENTRA_USER_ROLE_NAMES`
+
+Operators tuning role names against a live Entra app registration will hit
+this friction more often, and the pod-restart requirement is now an
+explicitly-documented operational caveat in the new operator runbook. We
+should remove the caveat rather than canonize it.
+
+## Design Sketch
+
+This is a tracking proposal — a full design is deferred. Open questions /
+candidate approaches:
+
+1. **In-process re-read on signal.** A `SIGHUP` (or platform-equivalent) handler
+   that calls `getProviderBundle({ reload: true })`, atomically swapping the
+   cached bundle. Cheap, but requires a process-level signal and isn't
+   ergonomic on AKS without a sidecar.
+
+2. **TTL-based re-read.** A short TTL (e.g. 30s) on `cachedBundle` with
+   transparent rebuild on access. Simple; trades a tiny per-request cost for
+   eventual consistency.
+
+3. **Config file with watcher.** Move `PORTAL_AUTHZ_*` into a mounted
+   `ConfigMap` JSON file and watch the file for changes. Plays well with
+   Kubernetes' existing ConfigMap update flow (atomic symlink swap).
+
+4. **Management-API endpoint.** A privileged endpoint that triggers reload.
+   Mirrors how some other dynamic settings get refreshed today.
+
+Whichever approach is chosen, the public contract should be:
+
+- `authorizePrincipal(principal, explicitPolicy)` continues to work — tests
+  already bypass the cache by passing an explicit policy, so this proposal is
+  purely about runtime ergonomics.
+- The `AuthorizationDecision` shape MUST NOT change.
+- The reload must be atomic (no torn reads of a half-built policy).
+
+## Non-Goals
+
+- This is not a request for live reload of provider type (e.g. flipping from
+  `entra` to `none` at runtime). Provider type changes can keep the
+  restart-required posture.
+- This is not a request for per-request policy evaluation (the per-process
+  cache is correct; only the lack of *invalidation* is the problem).
+
+## Filed By
+
+Surfaced during the Entra App-Roles Modernization work (see
+`docs/proposals/portal-auth-provider-and-authz.md` and
+`docs/portal-entra-app-roles.md`). The underlying caching behavior predates
+that feature; this proposal exists so the follow-up isn't lost.


### PR DESCRIPTION
## Summary

Planning PR for **Entra App-Roles Modernization** (Phase 2.5 of `docs/proposals/portal-auth-provider-and-authz.md`).

This PR adds **one** small tracking proposal that was surfaced during the planning work:

- `docs/proposals/portal-auth-config-reloader.md` — tracks the follow-up need for a config-reloader pattern so that `PORTAL_AUTHZ_*` env-var changes (especially the new `PORTAL_AUTHZ_ENTRA_*_ROLE_NAMES` knobs introduced by this feature) can take effect without a portal pod restart. The underlying per-process caching predates this feature; this proposal exists so the follow-up isn't lost.

## Planning Artifacts

This work uses the **never-commit** artifact lifecycle (`.paw/` is gitignored repo-wide), so the planning artifacts themselves are **not** in this PR. They live locally in `.paw/work/entra-app-roles-modernization/`:

- `Spec.md` — 3 user stories (P1 role-driven assignment, P2 explicit pinning, P3 unified operator setup), 17 FRs, 7 SCs
- `CodeResearch.md` — 8 sections covering existing engine code, config patterns, test layout, doc surfaces
- `ImplementationPlan.md` — 2 phases (engine + 25 tests; documentation), all 17 FRs and 7 SCs traced
- `reviews/planning/` — multi-model planning review by gpt-5.2 + claude-opus-4.6 (9 findings, all resolved before this PR)

## Scope of the Implementation Work (for context)

Phase 2.5 will (in subsequent phase PRs):

- **Engine change** (`packages/portal/auth/authz/engine.js`): elevate the JWT `roles` claim from a quiet fallback to the authoritative signal when present. Case-insensitive suffix-strip default (`Portal.Admin`, `pilotswarm.admin`, bare `admin` all → engine role `admin`). Admin-before-user precedence preserved. Provider-neutral by construction.
- **Config change** (`packages/portal/auth/config.js`): new `policy.roleNames` field; new env vars `PORTAL_AUTHZ_ENTRA_ADMIN_ROLE_NAMES` / `PORTAL_AUTHZ_ENTRA_USER_ROLE_NAMES` (explicit lists **replace** the suffix-strip default).
- **Tests** (`packages/sdk/test/local/portal-authz.test.js`): 25 new cases including a pinned reason-string contract for the new deny path.
- **Docs**: new operator runbook `docs/portal-entra-app-roles.md` plus cross-links from `packages/portal/README.md`, `docs/configuration.md`, `docs/deploying-to-aks.md`, `.env.example`, and a `CHANGELOG.md` migration note.

`AuthorizationDecision` JSON shape and `getPublicAuthContext` output shape are explicitly preserved.

## Behavior-Change Risk Note

Deployments today running with **both** an email allowlist **and** JWTs that carry app-role claims will see roles take precedence over the allowlist after this change. The operator runbook documents the new precedence and the two mitigation paths (configure an explicit `roleNames` sentinel, or strip the `roles` claim from token issuance).

🐾 Generated with [PAW](https://github.com/lossyrob/phased-agent-workflow)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
