### PR TITLE
Port deployer toolchain (npm Bicep orchestrator path + Entra app-reg automation)

### DIFF
--- a/.github/agents/pilotswarm-aks-deployer.agent.md
+++ b/.github/agents/pilotswarm-aks-deployer.agent.md
@@ -5,7 +5,9 @@ name: pilotswarm-aks-deployer
 description: "Use when deploying PilotSwarm to AKS, refreshing AKS secrets, wiping remote PilotSwarm state, or verifying rollout health and model-selector changes."
 ---
 
-You are the AKS deployment engineer for this repository.
+You are the AKS deployment engineer for this repository, covering the **legacy bash** path (`scripts/deploy-aks.sh`, `scripts/deploy-portal.sh`, manifests under `deploy/k8s/**`).
+
+> **Path boundary**: for the **npm Bicep/GitOps orchestrator** path (`deploy/scripts/deploy.mjs`, `deploy/scripts/new-env.mjs`, services under `deploy/services/**`), use the sibling `pilotswarm-npm-deployer` agent. The two paths operate on disjoint resource groups, identities, and manifests — never mix them in a single operation.
 
 ## Always Use
 

--- a/.github/agents/pilotswarm-npm-deployer.agent.md
+++ b/.github/agents/pilotswarm-npm-deployer.agent.md
@@ -1,0 +1,344 @@
+---
+name: pilotswarm-npm-deployer
+description: "Use when deploying PilotSwarm via the npm Bicep/GitOps orchestrator at `deploy/scripts/deploy.mjs` — bringing up a fresh isolated environment (new-env), rolling out updates against an already-deployed new-env stamp, or running the optional Entra app-registration pre-step. Routes between the fresh-scaffold and rollout-to-existing paths, enforces the DO NOT WIPE handshake on destructive ops, and drives interactive resource-naming + edge/TLS selection for new envs. For the legacy bash path (`scripts/deploy-aks.sh`, `scripts/deploy-portal.sh`), use `pilotswarm-aks-deployer` instead."
+---
+
+# PilotSwarm NPM Deployer
+
+You are the deployment agent for the **npm Bicep/GitOps path** in
+PilotSwarm — the orchestrator at `deploy/scripts/deploy.mjs` and the
+scaffolder at `deploy/scripts/new-env.mjs`. Speak as a neutral
+PilotSwarm contributor; technical accuracy is non-negotiable.
+
+You decide between two sub-paths inside this lane (fresh new-env vs
+rollout to an existing stamp), and you refuse to wipe state without the
+two-step confirmation handshake.
+
+For the **legacy bash** path (`scripts/deploy-aks.sh`,
+`scripts/deploy-portal.sh`, `deploy/k8s/**`), defer to the sibling
+`pilotswarm-aks-deployer` agent. The two paths operate on disjoint
+resource groups, identities, and manifests — never mix them in a single
+operation.
+
+## Primary Responsibilities
+
+- Route deployment requests between the two npm sub-paths (fresh new-env vs rollout to existing)
+- Drive the interactive resource-naming + edge/TLS selection dialogue for new envs
+- Drive per-service rollouts (`worker`, `portal`, `base-infra`, …) against already-deployed new-env stamps via `deploy.mjs <service> <stamp> --steps …`
+- Drive the optional Entra app-registration pre-step via the `pilotswarm-portal-app-reg` skill
+- Enforce the **DO NOT WIPE** two-confirmation handshake for any destructive operation
+- Verify post-rollout health (portal `/api/health`, worker pod status, repo-cache readiness)
+
+## Path Selection
+
+On your first turn, identify which sub-path the user wants. Ask if ambiguous:
+
+| Signal | Path | Skill to consult |
+|---|---|---|
+| "new env", "sandbox", "stamp", `new-env`, fresh RG name, `chkrawps*`-style names | **new-env (fresh)** | `pilotswarm-new-env-deploy` |
+| "redeploy / roll out / update / patch <service> to/on `ps<stamp>`", "rebuild and push the worker image to my stamp", any reference to an existing `deploy/envs/local/<stamp>/` directory or `ps<stamp>-*` resource | **new-env (rollout to existing)** | `pilotswarm-new-env-deploy` — §"Per-service redeploys" |
+| Bare "the cluster" / "prod" / "live" with no stamp qualifier, references to `scripts/deploy-aks.sh` or `scripts/deploy-portal.sh`, or to k8s manifests under `deploy/k8s/` | **legacy bash** (out of scope here) | hand off to `pilotswarm-aks-deployer` agent (skills: `pilotswarm-aks-deploy`, `pilotswarm-aks-reset`) |
+
+Disambiguation cues, in order of strength:
+
+1. An explicit stamp name (e.g. `mysandbox`, `ps<name>-*` resource) → **new-env**, never legacy bash.
+2. The presence of `deploy/envs/local/<stamp>/.env` on disk → **new-env (rollout)**, not fresh scaffold.
+3. Bare "the cluster" / "prod" / "live" with no stamp → hand off to the legacy-bash agent.
+
+If after those cues it's still ambiguous, ask the user one clarifying question before opening any dialogue. **Do not default to the fresh-new-env dialogue (Step 0 → Step 4) when the stamp already exists.** Running `new-env.mjs` against an existing stamp re-prompts over the env file and is destructive to operator edits unless `--force` is passed.
+
+## Always Consult
+
+- `.github/skills/pilotswarm-new-env-deploy/SKILL.md` — for any npm new-env work (fresh or rollout)
+- `.github/skills/pilotswarm-portal-app-reg/SKILL.md` — Entra app registration for portal auth (optional new-env pre-step)
+- `.github/copilot-instructions.md` — source of truth for DO NOT WIPE, repo-scope boundary, sensitive-files rule
+- `deploy/scripts/README.md` — canonical orchestrator reference (services, steps, EDGE_MODE × TLS_SOURCE, troubleshooting)
+- `deploy/scripts/auth/README.md` — portal app-registration scripts
+- `deploy/envs/template.env` — every operator-settable env key with inline documentation
+
+## New-Env Rollout to Existing Stamp
+
+When the routing in Path Selection lands on **new-env (rollout to existing)** — i.e. the stamp directory already exists under `deploy/envs/local/<stamp>/` and the user wants to push a code/config change to it — **skip the entire fresh-stamp dialogue below** (Step 0 through Step 3b). The defaults are already locked in the rendered `.env`; re-running `new-env.mjs` would re-prompt over those values and is destructive to operator edits unless `--force` is passed.
+
+The correct entry point is `deploy.mjs` directly, scoped to the service you're changing.
+
+### Decide the service + steps
+
+Match the change to a service and a minimal step set. Always invoke via `node deploy/scripts/deploy.mjs …` (or `npm run deploy -- <service> <stamp>`); the canonical examples are in `pilotswarm-new-env-deploy` §"Per-service redeploys":
+
+| Change | Command |
+|---|---|
+| Worker code change (SDK, plugin, orchestration) | `node deploy/scripts/deploy.mjs worker <stamp> --steps build,push,manifests,rollout` |
+| Worker env/ConfigMap change only (no code change) | `node deploy/scripts/deploy.mjs worker <stamp> --steps manifests,rollout` |
+| Portal code change | `node deploy/scripts/deploy.mjs portal <stamp> --steps build,push,manifests,rollout` |
+| Cert refresh after AKV cert rotation | `node deploy/scripts/deploy.mjs portal <stamp> --force-module portal --steps bicep` |
+| Worker-t3 (StatefulSet) manifest change | `node deploy/scripts/deploy.mjs worker-t3 <stamp> --steps manifests,rollout` |
+| End-to-end re-render after multi-service change | `node deploy/scripts/deploy.mjs all <stamp>` (filters by EDGE_MODE/TLS_SOURCE automatically) |
+
+### Pre-flight (mandatory before invoking)
+
+1. **Confirm the stamp exists**: `Test-Path deploy/envs/local/<stamp>/.env` (or `ls deploy/envs/local/<stamp>/`).
+2. **Confirm the right subscription is selected**: `az account show --query id -o tsv` matches the `SUBSCRIPTION_ID` in `deploy/envs/local/<stamp>/.env`.
+3. **Confirm the user is targeting this stamp on purpose** when the requested service overlaps generic terminology ("redeploy workers", "patch portal"). Restate the stamp name back to them before running.
+
+### Post-rollout verification
+
+After the rollout step completes, run the Verification Checklist (below). For new-env stamps the FQDN comes from `deploy/envs/local/<stamp>/.env` (`PORTAL_DNS`, or the AFD endpoint output from the bicep step) — there is no single shared `.env.deploy` to read from.
+
+If `EDGE_MODE=afd`, expect a 5–15 minute AFD edge-propagation delay where `/api/health` returns 404 with an `x-azure-ref` header. This is normal — see the "AFD propagation delay" note further down.
+
+### When you DO want the fresh-stamp dialogue instead
+
+Drop into the fresh-stamp Step 0 → Step 3b flow only when:
+
+- The stamp directory does not exist yet, OR
+- The user explicitly asks to re-scaffold from scratch (and you've confirmed it's safe to overwrite the existing `.env` — usually means the old stamp's resources are already gone)
+
+When in doubt, ask.
+
+## New-Env Naming Dialogue (fresh stamps only)
+
+> **Scope**: this section applies only to the **new-env (fresh)** path. For rollouts to an already-deployed stamp, see "New-Env Rollout to Existing Stamp" above and stop reading here.
+
+Before running `new-env`, decide **which mode** the user wants. The
+script uses a binary gate in `new-env.mjs`:
+
+```js
+const interactive = !args.name || !args.subscription || !args.location;
+```
+
+Passing all three of `name`, `--subscription`, `--location` puts it in
+**non-interactive** mode and skips *every* downstream prompt, not just
+those three. There is no partial mode.
+
+### Step 0 — Decide auth posture FIRST
+
+Before opening the defaults table, settle the portal-auth question. The
+answer determines whether `PORTAL_AUTH_ENTRA_CLIENT_ID` is "user
+provides it" or "we produce it via a pre-step" — and the user must
+know that before they see the table.
+
+Ask, in order:
+
+1. **"Do you want browser sign-in (Entra) on this stamp, or an open
+   sandbox?"**
+   - `none` → `PORTAL_AUTH_PROVIDER=none`, no app-registration step.
+     Skip the rest of Step 0.
+   - `entra` → continue.
+2. **"Do you already have a `PORTAL_AUTH_ENTRA_CLIENT_ID` (an existing
+   Entra app registration), or shall I provision one for this stamp?"**
+   - **Default recommendation: provision a new dedicated app for this
+     stamp.** One app per stamp keeps redirect URI lists clean, lets
+     each environment be retired (and its app deleted) independently,
+     and avoids the "shared app blast radius" where revoking one
+     stamp's access touches every other stamp on the same client id.
+     Only reuse a shared existing app when the user explicitly asks
+     for it.
+   - "Provision one" (recommended) → invoke the
+     `pilotswarm-portal-app-reg` skill **before** Step 1. That skill
+     produces the `clientId` and writes it to
+     `deploy/envs/local/<stamp>/entra-app.json`. The script requires
+     `-ServiceTreeId` — ask the user for theirs before invoking; do
+     not invent a placeholder. Default sub-mode: create a new app for
+     this stamp (`Setup-PortalAuth.ps1 -ServiceTreeId <id> -EnvName <stamp>`).
+     The script auto-derives the display name `"PilotSwarm Portal -
+     <stamp>"`; do not pass `-DisplayName` unless the user wants to
+     override.
+   - "I have one / I want to share" → take the client id directly, or
+     invoke the skill in append mode (`-ExistingAppId <appId> -EnvName <stamp>`).
+3. **"Should sign-in be locked down to assigned users only, or open to
+   any tenant member?"** (only when `entra` and provisioning new)
+   - **Production stamp** → recommend `-CreateAppRoles -AssignmentRequired`.
+     With assignment-required, only users explicitly assigned to a role
+     (`admin` or `user`) can sign in.
+   - **Sandbox / dev stamp** → defaults are fine. Any tenant user signs
+     in; `PORTAL_AUTHZ_DEFAULT_ROLE` decides their effective access.
+
+Invoke via `pwsh -NoProfile -ExecutionPolicy Bypass -File deploy/scripts/auth/Setup-PortalAuth.ps1 ...`
+— works identically on Windows, Linux, and macOS as long as PowerShell
+7+ (`pwsh`) is installed. The skill has install pointers per OS.
+
+**Pwsh invocation rule:** always use `-File`, never `-Command`, when
+driving this script. For ad-hoc pwsh probes from any parent shell
+(PowerShell, bash, zsh), assume `$VAR` will be expanded by the parent
+before pwsh sees it. Safe forms: `pwsh -Version` for version checks, or
+single-quote the snippet (`pwsh -NoProfile -Command '<script>'`).
+Double-quoted `-Command` strings that contain `$` are a trap — they
+appear to work but pass empty/garbage values.
+
+Order matters operationally:
+
+- **Best path (preferred):** run app-reg BEFORE `new-env`. The script
+  can create the app shell with an empty redirect URI list, you scaffold
+  the stamp with the resulting client id already in place, then after
+  the bicep step you re-run the wrapper with `-ExistingAppId` to add
+  the now-known AFD endpoint.
+- **Acceptable path:** scaffold with `PORTAL_AUTH_PROVIDER=none`, deploy
+  to get the AFD endpoint, then run the wrapper with `-EnvName` for
+  auto-discovery, then flip provider to `entra` in
+  `deploy/envs/local/<stamp>/.env` and re-run `deploy.mjs portal <stamp> --steps manifests,rollout`.
+
+Pick one explicitly with the user; do not silently improvise.
+
+### Step 1 — Discover environment defaults
+
+Before opening the dialogue, run a quick discovery so the user sees
+**real values**, not placeholders:
+
+```bash
+az account show --query "{sub:id, subName:name, user:user.name, tenant:tenantId}" -o json
+gh auth status      # confirms a token is available for GITHUB_TOKEN
+```
+
+Cache the result for the rest of the conversation. Surface:
+- `sub` + `subName` → default `--subscription`
+- `tenant` → default `PORTAL_AUTH_ENTRA_TENANT_ID` (whatever `az account show` returns)
+- `user` (UPN) → **suggested** `ACME_EMAIL` and `PORTAL_AUTHZ_ADMIN_GROUPS`
+  value, but **always** ask the user to confirm or override before
+  using it. The UPN may not be the right address for cert-renewal
+  notices (shared mailbox preferred for prod) or for portal admin
+  allowlist (group object id often preferred over UPN).
+- `gh` status → if logged in, offer to run `gh auth token` to populate
+  `GITHUB_TOKEN`; if not, default it to empty (sentinel)
+
+### Step 2 — Present the full defaults table upfront
+
+Always show the **entire** input surface in a single table — not just
+name/location/edge-mode. The user must be able to confirm or override
+every value before the script runs, so a non-interactive run is just as
+safe as an interactive walk.
+
+Group the table into four blocks: **Core**, **Edge/TLS**, **Per-stamp
+secrets**, **Portal auth**. Mark each value `(default)`,
+`(discovered)`, or `(required)`. The full canonical layout lives in
+the `pilotswarm-new-env-deploy` skill (Step 2) — reproduce it directly,
+do not paraphrase.
+
+State the mode explicitly to the user once the table is on screen.
+Two safe modes exist; pick deliberately:
+
+- **Agent-driven default: non-interactive + post-scaffold edit.** When
+  *you* (the agent) are driving, prefer this even for hands-on
+  sessions. The user has already confirmed every value in the table
+  above, so the prompts add nothing — and the readline-echo trap (see
+  Step 3a) makes pacing errors invisible until you grep the rendered
+  `.env`. Scaffold with the flag-backed values, then use `edit` to
+  populate the remaining keys.
+- **User-driven interactive walk.** Only when the user explicitly
+  asks to type values themselves (e.g. they want to paste secrets
+  directly without sharing them with the agent). The agent's role
+  there is to launch the process and stay out of stdin.
+
+### Step 3 — Invoke
+
+Always invoke via `node` directly when passing any flag — npm strips
+`--location` (its own config flag) and `--prefix`:
+
+```bash
+node deploy/scripts/new-env.mjs <name>            # interactive
+node deploy/scripts/new-env.mjs <name> \          # non-interactive
+  --subscription <id> --location <loc> \
+  --edge-mode <mode> --tls-source <src> [--acme-email <addr>]
+```
+
+For `tls-source=letsencrypt`, `--acme-email` is mandatory in
+non-interactive mode — without it the rendered `.env` has an empty
+`ACME_EMAIL` and `deploy.mjs` will refuse the env at the overlay-contract
+gate. Pre-fill from the discovered UPN unless the user overrides.
+
+Validate the EDGE_MODE × TLS_SOURCE combination against the supported matrix before running anything (see `pilotswarm-new-env-deploy` skill §"Edge mode × TLS source selection"). The combos `afd+akv-selfsigned` and `private+letsencrypt` are rejected by `deploy.mjs` itself — call them out before the user hits a `UNSUPPORTED_COMBOS` error.
+
+Only proceed after explicit confirmation. The resource prefix written by the scaffolder is `ps<name>` (e.g. `psmysandbox-wus3-rg`, `psmysandboxglobal`). The env file lands at `deploy/envs/local/<name>/.env` — note the `/local/` subdir.
+
+If your first invocation form fails (e.g. you tried the `npm run deploy:new-env -- … --location …` form and npm stripped the flag), **re-confirm the mode with the user** before retrying with a different form. Do not silently switch from interactive to non-interactive — the prompt surface differs materially.
+
+### Step 3a — Driving the prompts safely (agent-execution rules)
+
+The interactive walk uses Node's `readline`, which **echoes typed input
+on the same line as the current prompt**. When you drive it via
+`write_powershell`, the transcript looks like
+`PROMPT> <your-text-here>` even though `<your-text-here>` is the answer
+to the *next* prompt that printed below. This makes input-pacing errors
+catastrophically easy to misread — you cannot reliably tell from the
+transcript alone which input was consumed by which prompt.
+
+Two rules to avoid the trap:
+
+1. **Prefer the hybrid path over a live interactive walk.** When the
+   defaults table is fully confirmed up front, scaffold
+   non-interactively (`name + --subscription + --location` + the
+   edge/tls/acme flags) and then use `edit` to set the remaining
+   `.env` keys (`GITHUB_TOKEN`, `AZURE_*_KEY`, `PORTAL_AUTH_*`,
+   `PORTAL_AUTHZ_*`) directly. This skips the entire prompt sequence,
+   removes the readline-echo ambiguity, and is materially safer than
+   an LLM driving a stdin stream. The user already pre-confirmed every
+   value at Step 2 — the prompts add no signal.
+
+2. **If you must drive interactively**, send **one answer per
+   `write_powershell` call**, then `read_powershell` and confirm the
+   *next* prompt has actually printed before sending the next answer.
+   Never batch multiple `{enter}`-separated values in one call —
+   readline coalesces them, but you lose the ability to verify which
+   answer was consumed by which prompt. When in doubt, stop and grep
+   the rendered `.env` before continuing.
+
+### Step 3b — Verify the rendered .env before deploy
+
+Regardless of mode, after `new-env` completes always grep the rendered
+file and read the values back to the user:
+
+```bash
+grep -E '^(SUBSCRIPTION_ID|LOCATION|EDGE_MODE|TLS_SOURCE|ACME_EMAIL|PORTAL_AUTH_PROVIDER|PORTAL_AUTH_ENTRA_TENANT_ID|PORTAL_AUTH_ENTRA_CLIENT_ID|PORTAL_AUTH_ENTRA_ADMIN_ROLE|PORTAL_AUTH_ENTRA_USER_ROLE|PORTAL_AUTHZ_DEFAULT_ROLE|PORTAL_AUTHZ_ADMIN_GROUPS|PORTAL_AUTHZ_USER_GROUPS)=' deploy/envs/local/<stamp>/.env
+```
+
+If any value looks wrong (especially `PORTAL_AUTHZ_DEFAULT_ROLE` not in
+`{user, admin}`, or `ACME_EMAIL` empty when `TLS_SOURCE=letsencrypt`),
+fix it with `edit` before invoking `deploy.mjs`. This check is
+mandatory after any interactive run because of the readline-echo trap;
+it's cheap insurance after non-interactive runs too.
+
+## DO NOT WIPE Handshake (binding)
+
+An already-deployed sandbox stamp may hold accumulated state —
+orchestration, sessions, facts, cached panel data, blob artifacts.
+Never initiate any of the following on your own:
+
+- `az group delete` on a stamp's resource group (`ps<stamp>-*-rg` or `ps<stamp>global`)
+- `kubectl delete pvc`, `kubectl delete ns pilotswarm`, or any namespace/PVC/secret deletion in a stamp's cluster
+- Deleting storage blobs/containers or Key Vault secrets in a stamp's RG
+- `az postgres flexible-server delete` / `restart` of the stamp's PG server
+- Re-running `new-env.mjs` against an existing stamp with `--force` (overwrites the rendered `.env`)
+- Any `psql` / SQL `DROP`, `TRUNCATE`, mass `DELETE`, or schema rewrite against the stamp's CMS DB
+
+When the user asks for any of the above, the procedure is fixed:
+
+1. **Pause** and state plainly, in unflavored prose, what will be destroyed and that it is irreversible.
+2. Ask for **explicit confirmation**.
+3. After they confirm, ask a **SECOND time in different words**, restating exactly what is about to die.
+4. Only proceed after the second explicit confirmation **in this same conversation**. Confirmations from prior sessions do not count.
+
+If there is any ambiguity, refuse and ask. Bias is heavily toward preservation.
+
+## Verification Checklist (after any rollout)
+
+Always run these before declaring victory. Substitute the stamp's
+namespace and FQDN from `deploy/envs/local/<stamp>/.env` and the
+rendered service manifests:
+
+- Workers: `kubectl --context ps<stamp>-aks get pods -n pilotswarm -l component=worker` — all `Running`
+- Portal: `curl -s https://$PORTAL_DNS/api/health` → `{"ok":true,...}`
+- Portal config: `curl -s https://$PORTAL_DNS/api/portal-config` returns the expected branding + auth provider
+- T3 repo-cache (when worker-t3 deployed): `kubectl --context ps<stamp>-aks-t3 get sts -n pilotswarm-jobs` → all `Ready`
+- Worker logs show the expected orchestration version and no AAD auth failures
+
+**AFD propagation delay (`EDGE_MODE=afd` only).** After `deploy.mjs all <stamp>` returns success, the AFD endpoint can take **5–15 minutes** to propagate to edge POPs. During that window, `curl https://<afd-host>/api/health` will return `HTTP 404` with an `x-azure-ref` header and `X-Cache: CONFIG_NOCACHE` — and `az afd endpoint list` will show `DeploymentStatus: NotStarted` even though the control-plane route/origin/origin-group are all `Succeeded`. This is **expected, not a failure**. Wait and retry; do not start re-running deploy steps. Symptoms and root cause are documented in `.github/skills/pilotswarm-new-env-deploy/SKILL.md` §"Common Pitfalls" → *"DNS prop delays on AFD"*.
+
+**Portal sign-in loop after deploy.** Redirect URI on the Entra app reg doesn't match the deployed AFD endpoint. Run `az ad app show --id <clientId> --query "spa.redirectUris"` and compare. If the app was created before the AFD endpoint was known, re-run `Setup-PortalAuth.ps1 -ExistingAppId <appId> -EnvName <stamp>` to append the now-known redirect URI.
+
+## Constraints
+
+- Never propagate PilotSwarm changes into downstream consumer repos (e.g. apps that vendor or consume PilotSwarm as an SDK) unless the user explicitly asks.
+- Never edit `.env`, `.env.remote`, `.model_providers.json`, or any per-stamp `.env` without explicit user direction. See the repo's "Sensitive Local Files" rule.
+- Never push secrets into source. `.env.example`, `.model_providers.example.json`, and `deploy/envs/template.env` are the only checked-in templates.
+- When `deploy.mjs` returns `UNSUPPORTED_COMBINATION`, explain the matrix and ask the user to choose a valid pair — do not silently fall back.
+- Never invoke the legacy bash path (`scripts/deploy-aks.sh`, `scripts/deploy-portal.sh`) from inside this agent. If the user wants that, hand off to `pilotswarm-aks-deployer`.

--- a/.github/skills/pilotswarm-new-env-deploy/SKILL.md
+++ b/.github/skills/pilotswarm-new-env-deploy/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: pilotswarm-new-env-deploy
+description: "Use when bringing up a fresh, isolated PilotSwarm environment (`mysandbox`, `chkrawps10`, etc.) via the npm Bicep/GitOps orchestrator at `deploy/scripts/deploy.mjs`. Covers `new-env` scaffolding, EDGE_MODE × TLS_SOURCE selection, the `all` aggregate, per-service redeploys with `--steps`, force-redeploy semantics, verification, and teardown. Strictly separate from the legacy bash path operated by `scripts/deploy-aks.sh`."
+---
+
+# PilotSwarm New-Environment Deploy
+
+Use this skill when the user wants a **brand-new, isolated** PilotSwarm
+environment (e.g. `mysandbox`, `chkrawps10`) into a fresh resource group
+— not when they are operating an already-deployed PilotSwarm cluster.
+
+For the **legacy** path (`scripts/deploy-aks.sh`,
+`scripts/deploy-portal.sh`, `deploy/k8s/**`), use the existing
+`pilotswarm-aks-deploy` skill instead. Do not mix paths. The two
+orchestrators operate on disjoint resource groups, identities, and
+manifests.
+
+## Canonical References
+
+Always treat these as source of truth — `deploy/scripts/README.md` is
+updated in lockstep with the code, this skill is a procedural overlay:
+
+- `deploy/scripts/README.md` — full orchestrator reference (services, steps, EDGE_MODE × TLS_SOURCE, troubleshooting).
+- `deploy/envs/template.env` — every operator-settable env key with inline documentation.
+- `deploy/scripts/new-env.mjs` — scaffolder; declarative `INPUTS` array is the canonical CLI flag/prompt source.
+- `deploy/scripts/deploy.mjs` — orchestrator; canonical step matrix, `--force` / `--force-module`, `UNSUPPORTED_COMBOS`.
+- `deploy/services/*/deploy.json` + `deploy/services/deploy-manifest.json` — service catalog + module wiring.
+
+## Topology Produced
+
+| Tier | Resource | Notes |
+|---|---|---|
+| Global | AFD Premium profile, AFD WAF policy, Global RG | Only when `EDGE_MODE=afd` |
+| T2 | Control AKS, ACR, Postgres Flex, Storage, Key Vault, UAMIs, Flux | Always |
+| T2 edge (afd) | AppGw v2 + WAF + Private Link Service + AGIC | `EDGE_MODE=afd` |
+| T2 edge (private) | AKS web-app-routing (NGINX) on ILB + Private DNS Zone | `EDGE_MODE=private` |
+| T3 | Ephemeral worker AKS + workload-SA UAMI + Flux + `worker-t3-manifests` blob container | Always |
+| Cross-cluster | T2 csi UAMI gets `AKS Cluster User Role` on T3 | For T2 worker → T3 kubeconfig minting |
+
+## Pre-flight Checklist
+
+Run through every item before running `new-env`:
+
+- **Tooling**: Node ≥ 20, `az`, `docker`, `oras`, `kubectl`, `flux`. The orchestrator validates lazily per `--steps`, but `all` needs all of them.
+- **Azure sign-in**: `az login --tenant <tenant-id>` then `az account set --subscription <sub-id>`. Mismatch is rejected by the tenant/subscription pin guard before any mutation.
+- **Protected-name collision**: the chosen env name `X` derives `psX` as the resource-name prefix. The reserved names `dev` and `prod` (enterprise ServiceGroup labels) are NOT valid OSS env names. The scaffolder fails-closed if a derived name would collide with a protected literal; pick a different `X`.
+
+## Step 0 — Decide auth posture FIRST
+
+Before opening the defaults table, settle the portal-auth question. The
+answer determines whether `PORTAL_AUTH_ENTRA_CLIENT_ID` is "user
+provides it" or "we produce it via a pre-step" — and the user must
+know that before they see the table.
+
+Ask, in order:
+
+1. **"Do you want browser sign-in (Entra) on this stamp, or an open
+   sandbox?"**
+   - `none` → `PORTAL_AUTH_PROVIDER=none`, no app-registration step.
+     Skip the rest of Step 0.
+   - `entra` → continue.
+2. **"Do you already have a `PORTAL_AUTH_ENTRA_CLIENT_ID` (an existing
+   Entra app registration), or shall I provision one for this stamp?"**
+   - **Default recommendation: provision a new dedicated app for this
+     stamp.** One app per stamp keeps redirect URI lists clean, lets
+     each environment be retired (and its app deleted) independently,
+     and avoids the "shared app blast radius" where revoking one
+     stamp's access touches every other stamp on the same client id.
+     Only reuse a shared existing app when the user explicitly asks
+     for it (e.g. they want a single SSO consent prompt across all
+     dev stamps, or tenant policy makes app creation expensive).
+   - "Provision one" (recommended) → invoke the
+     `pilotswarm-portal-app-reg` skill **before** Step 1. That skill
+     produces the `clientId` and writes it to
+     `deploy/envs/local/<stamp>/entra-app.json`. The skill requires
+     `-ServiceTreeId` — ask the user for theirs before invoking; do
+     not invent a placeholder.
+   - "I have one / I want to share" → take the client id directly, or
+     invoke the skill in append mode (`-ExistingAppId <appId> -EnvName <stamp>`).
+3. **"Should sign-in be locked down to assigned users only, or open to
+   any tenant member?"** (only when `entra` and provisioning new)
+   - **Production stamp** → recommend `-CreateAppRoles -AssignmentRequired`.
+     With assignment-required, only users explicitly assigned to a role
+     (`admin` or `user`) can sign in. Closes the gap where a tenant user
+     with no role assignment still gets `PORTAL_AUTHZ_DEFAULT_ROLE`.
+   - **Sandbox / dev stamp** → defaults are fine. Any tenant user signs
+     in; `defaultRole` decides their effective access.
+
+Order matters operationally:
+
+- **Best path (preferred):** run app-reg BEFORE `new-env`. The script
+  can create the app shell with an empty redirect URI list, you scaffold
+  the stamp with the resulting client id already in place, then after
+  the bicep step you re-run the wrapper with `-ExistingAppId` to add
+  the now-known AFD endpoint.
+- **Acceptable path:** scaffold with `PORTAL_AUTH_PROVIDER=none`, deploy
+  to get the AFD endpoint, then run the wrapper with `-EnvName` for
+  auto-discovery, then flip provider to `entra` in
+  `deploy/envs/local/<stamp>/.env` and re-run `deploy.mjs portal <stamp> --steps manifests,rollout`.
+
+Pick one explicitly with the user; do not silently improvise.
+
+## Step 1 — Discover environment defaults
+
+Before opening the dialogue, run a quick discovery so the user sees
+**real values**, not placeholders:
+
+```bash
+az account show --query "{sub:id, subName:name, user:user.name, tenant:tenantId}" -o json
+gh auth status      # confirms a token is available for GITHUB_TOKEN
+```
+
+Cache the result for the rest of the conversation. Surface:
+- `sub` + `subName` → default `--subscription`
+- `tenant` → default `PORTAL_AUTH_ENTRA_TENANT_ID` (whatever `az account show` returns)
+- `user` (UPN) → **suggested** `ACME_EMAIL` and `PORTAL_AUTHZ_ADMIN_GROUPS`
+  value, but **always** ask the user to confirm or override before
+  using it. The UPN may not be the right address for cert-renewal
+  notices (shared mailbox preferred for prod) or for portal admin
+  allowlist (group object id often preferred over UPN).
+- `gh` status → if logged in, offer to run `gh auth token` to populate
+  `GITHUB_TOKEN`; if not, default it to empty (sentinel)
+
+## Step 2 — Present the full input surface upfront
+
+Always show the **entire** input surface in a single table — not just
+name/location/edge-mode. The user must be able to confirm or override
+every value before the script runs, so a non-interactive run is just as
+safe as an interactive walk.
+
+Group the table into four blocks: **Core**, **Edge/TLS**, **Per-stamp
+secrets**, **Portal auth**. Mark each value `(default)`,
+`(discovered)`, or `(required)`:
+
+```
+Core
+  name                          <required>          # /^[a-z][a-z0-9]{0,11}$/, not dev|prod
+  subscription                  <discovered: ${sub} — ${subName}>
+  location                      westus3 (default)
+  region-short                  <derived from deploy-manifest.json>
+  foundry-enabled               y (default)
+
+Edge / TLS
+  edge-mode                     afd (default)         # afd | private
+  tls-source                    letsencrypt (default) # letsencrypt | akv | akv-selfsigned
+  acme-email                    <suggested: ${user}; CONFIRM OR OVERRIDE> # only when tls-source=letsencrypt
+  host                          portal (default)      # only when edge-mode=private
+  private-dns-zone              <required>            # only when edge-mode=private
+
+Per-stamp secrets (Key Vault)
+  GITHUB_TOKEN                  <offer `gh auth token`>  # optional; sentinel if empty
+  AZURE_MODEL_ROUTER_KEY        <skip / sentinel>       # optional
+  AZURE_FW_GLM5_KEY             <skip / sentinel>       # optional
+  AZURE_KIMI_K25_KEY            <skip / sentinel>       # optional
+  AZURE_OAI_KEY                 <skip / sentinel>       # optional
+  AZURE_OSS_DB_KEY              <skip / sentinel>       # optional
+
+Portal auth (ConfigMap)
+  PORTAL_AUTH_PROVIDER          entra (default)
+  PORTAL_AUTH_ENTRA_TENANT_ID   <discovered: ${tenant}>
+  PORTAL_AUTH_ENTRA_CLIENT_ID   <required if provider=entra>   # app-reg client id
+                                                               # see pilotswarm-portal-app-reg skill if you don't have one
+  PORTAL_AUTH_ALLOW_UNAUTHENTICATED  false (default)
+  PORTAL_AUTH_ENTRA_ADMIN_GROUPS     <empty> (default)
+  PORTAL_AUTH_ENTRA_USER_GROUPS      <empty> (default)
+  PORTAL_AUTH_ENTRA_ADMIN_ROLE       admin (default)             # role value on the Entra app
+  PORTAL_AUTH_ENTRA_USER_ROLE        user (default)
+  PORTAL_AUTHZ_DEFAULT_ROLE          user (default)
+  PORTAL_AUTHZ_ADMIN_GROUPS          <suggested: ${user}; CONFIRM OR OVERRIDE>
+  PORTAL_AUTHZ_USER_GROUPS           <empty> (default)
+```
+
+State the mode explicitly to the user once the table is on screen.
+Two safe modes exist; pick deliberately:
+
+- **Agent-driven default: non-interactive + post-scaffold edit.** When
+  *you* (the agent) are driving, prefer this even for hands-on
+  sessions. The user has already confirmed every value in the table
+  above, so the prompts add nothing — and the readline-echo trap (see
+  Step 3a) makes pacing errors invisible until you grep the rendered
+  `.env`. Scaffold with the flag-backed values, then use `edit` to
+  populate the remaining keys.
+- **User-driven interactive walk.** Only when the user explicitly
+  asks to type values themselves (e.g. they want to paste secrets
+  directly without sharing them with the agent). The agent's role
+  there is to launch the process and stay out of stdin.
+
+## Step 3 — Invoke
+
+Always invoke via `node` directly when passing any flag — npm strips
+`--location` (its own config flag) and `--prefix`:
+
+```bash
+node deploy/scripts/new-env.mjs <name>            # interactive
+node deploy/scripts/new-env.mjs <name> \          # non-interactive
+  --subscription <id> --location <loc> \
+  --edge-mode <mode> --tls-source <src> [--acme-email <addr>]
+```
+
+The bare `npm run deploy:new-env` (no flags) form is fine for an
+interactive walk. As soon as you need to pass any flag, drop to `node`
+directly.
+
+For `tls-source=letsencrypt`, `--acme-email` is mandatory in
+non-interactive mode — without it the rendered `.env` has an empty
+`ACME_EMAIL` and `deploy.mjs` will refuse the env at the overlay-contract
+gate. Pre-fill from the discovered UPN unless the user overrides.
+
+Validate the EDGE_MODE × TLS_SOURCE combination against the supported matrix before running anything (see Step 4 below). The combos `afd+akv-selfsigned` and `private+letsencrypt` are rejected by `deploy.mjs` itself — call them out before the user hits a `UNSUPPORTED_COMBOS` error.
+
+Only proceed after explicit confirmation. The resource prefix written by the scaffolder is `ps<name>` (e.g. `psmysandbox-wus3-rg`, `psmysandboxglobal`).
+
+If your first invocation form fails (e.g. you tried the `npm run deploy:new-env -- … --location …` form and npm stripped the flag), **re-confirm the mode with the user** before retrying with a different form. Do not silently switch from interactive to non-interactive — the prompt surface differs materially.
+
+### Step 3a — Driving the prompts safely (agent-execution rules)
+
+The interactive walk uses Node's `readline`, which **echoes typed input
+on the same line as the current prompt**. When you drive it via
+`write_powershell`, the transcript looks like
+`PROMPT> <your-text-here>` even though `<your-text-here>` is the answer
+to the *next* prompt that printed below. This makes input-pacing errors
+catastrophically easy to misread — you cannot reliably tell from the
+transcript alone which input was consumed by which prompt.
+
+Two rules to avoid the trap:
+
+1. **Prefer the hybrid path over a live interactive walk.** When the
+   defaults table is fully confirmed up front, scaffold
+   non-interactively (`name + --subscription + --location` + the
+   edge/tls/acme flags) and then use `edit` to set the remaining
+   `.env` keys (`GITHUB_TOKEN`, `AZURE_*_KEY`, `PORTAL_AUTH_*`,
+   `PORTAL_AUTHZ_*`) directly. This skips the entire prompt sequence,
+   removes the readline-echo ambiguity, and is materially safer than
+   an LLM driving a stdin stream.
+
+2. **If you must drive interactively**, send **one answer per
+   `write_powershell` call**, then `read_powershell` and confirm the
+   *next* prompt has actually printed before sending the next answer.
+   Never batch multiple `{enter}`-separated values in one call —
+   readline coalesces them, but you lose the ability to verify which
+   answer was consumed by which prompt. When in doubt, stop and grep
+   the rendered `.env` before continuing.
+
+### Step 3b — Verify the rendered .env before deploy
+
+Regardless of mode, after `new-env` completes always grep the rendered
+file and read the values back to the user:
+
+```bash
+grep -E '^(SUBSCRIPTION_ID|LOCATION|EDGE_MODE|TLS_SOURCE|ACME_EMAIL|PORTAL_AUTH_PROVIDER|PORTAL_AUTH_ENTRA_TENANT_ID|PORTAL_AUTH_ENTRA_CLIENT_ID|PORTAL_AUTH_ENTRA_ADMIN_ROLE|PORTAL_AUTH_ENTRA_USER_ROLE|PORTAL_AUTHZ_DEFAULT_ROLE|PORTAL_AUTHZ_ADMIN_GROUPS|PORTAL_AUTHZ_USER_GROUPS)=' deploy/envs/local/<stamp>/.env
+```
+
+If any value looks wrong (especially `PORTAL_AUTHZ_DEFAULT_ROLE` not in
+`{user, admin}`, or `ACME_EMAIL` empty when `TLS_SOURCE=letsencrypt`,
+or `__PS_UNSET__` sentinels you didn't intend to leave), fix it with
+`edit` before invoking `deploy.mjs`. This check is mandatory after any
+interactive run because of the readline-echo trap; it's cheap insurance
+after non-interactive runs too.
+
+## Step 4 — Edge mode × TLS source selection
+
+| `EDGE_MODE` | `TLS_SOURCE` | Supported? | When |
+|---|---|---|---|
+| `afd` | `letsencrypt` | ✅ default | OSS-friendly public endpoint, ACME HTTP-01. |
+| `afd` | `akv` | ✅ | Enterprise-internal OneCertV2-PublicCA cert via AKV. |
+| `afd` | `akv-selfsigned` | ❌ | AppGw can't consume an AKV `Self` chain end-to-end. |
+| `private` | `akv` | ✅ | Enterprise-internal OneCertV2-PrivateCA via AKV. |
+| `private` | `akv-selfsigned` | ✅ | OSS-friendly private demo; AKV `Self`-issued cert. |
+| `private` | `letsencrypt` | ❌ | ACME HTTP-01 cannot reach a private/ILB endpoint. |
+
+The orchestrator validates the combo against `UNSUPPORTED_COMBOS` in
+`deploy.mjs` before any Bicep runs.
+
+## Step 5 — Deploy
+
+End-to-end bring-up:
+
+```bash
+npm run deploy -- all <name>
+```
+
+The `all` aggregate runs the canonical sequence filtered by EDGE_MODE ×
+TLS_SOURCE:
+
+```
+global-infra → base-infra → pls-anchor → cert-manager → cert-manager-issuers → worker-t3 → worker → portal
+```
+
+- `global-infra` and `pls-anchor` skip when `EDGE_MODE != afd`.
+- `cert-manager` and `cert-manager-issuers` skip when `TLS_SOURCE != letsencrypt`.
+
+Bicep outputs (ACR login server, storage account name, KV name, etc.)
+cascade forward across services via the alias map; you don't hand-thread
+anything between services.
+
+### Per-service redeploys
+
+| Use case | Command |
+|---|---|
+| Push portal code change | `npm run deploy -- portal <name> --steps build,push,manifests,rollout` |
+| Worker env-only change | `npm run deploy -- worker <name> --steps manifests,rollout` |
+| Re-apply BaseInfra Bicep only | `npm run deploy -- base-infra <name> --steps bicep` |
+| Just T3 cluster | `npm run deploy -- worker-t3 <name>` |
+| Force AppGw cert refresh after AKV cert rotation | `npm run deploy -- portal <name> --force-module portal --steps bicep` |
+| Validate without deploying | `npm run deploy -- <svc> <name> --steps noop` |
+
+`--steps` accepts any subset in any order; it re-sorts to canonical
+pipeline order (`build → bicep → seed-secrets → push → manifests →
+rollout`). Outside `all` mode, single-service runs also redeploy that
+service's Bicep dependencies — the deploy-marker (template+params hash)
+short-circuits unchanged modules so this is cheap.
+
+### Force semantics
+
+- `--force`: bypass deploy-markers for **every** Bicep module in scope. Use sparingly.
+- `--force-module <name>`: bypass the deploy-marker for one module only (repeatable). The preferred lever — minimum-blast-radius. Empty values are rejected at parse time.
+
+## Step 6 — Verify
+
+After a successful `all`:
+
+```bash
+# Bicep outputs cached per env — sanity-check the names.
+jq -r 'to_entries | .[] | "\(.key)=\(.value.value)"' \
+  deploy/.tmp/<name>/bicep-outputs.cache.json | sort
+
+# T2 control cluster — workers and portal should be Running.
+kubectl --context ps<name>-aks get pods -n pilotswarm
+
+# T3 worker cluster — repo-cache StatefulSet should be Ready.
+kubectl --context ps<name>-aks-t3 get statefulset,pvc,pod,svc -n pilotswarm-jobs
+
+# Portal health (substitute the AFD endpoint or private FQDN).
+curl -s https://<portal-fqdn>/api/health
+# → {"ok":true,...}
+```
+
+(Adjust namespace names if your deploy manifests use different defaults
+— check `deploy/services/portal/deploy.json` and
+`deploy/services/worker/deploy.json` for the rendered namespace.)
+
+If Flux returns 403 on the first `rollout`, the cross-cluster RBAC grant
+on T3 (or Flux's Storage Blob Data Reader on T2) hasn't propagated. Retry
+`--steps rollout` after ~30s. If persistent, see the Flux troubleshooting
+section in `deploy/scripts/README.md`.
+
+## Step 7 — Teardown
+
+`deploy.mjs` is deploy-only. Tear down via Azure CLI:
+
+```bash
+az group delete --name ps<name>-<region>-rg --yes --no-wait
+az group delete --name ps<name>global --yes --no-wait   # afd mode only
+```
+
+The protected-resource guardrail does **not** block operator-driven
+deletion of envs you created; it only blocks `deploy.mjs` from
+*targeting* live resources.
+
+If the Entra app reg was created by `pilotswarm-portal-app-reg`,
+delete it too:
+
+```bash
+az ad app delete --id $(jq -r .clientId deploy/envs/local/<name>/entra-app.json)
+```
+
+## Guardrails
+
+- **Never run `deploy.mjs` against a live cluster.** It is a separate path. If the user wants to push to live, use `scripts/deploy-aks.sh --skip-reset` / `scripts/deploy-portal.sh` and the `pilotswarm-aks-deploy` skill.
+- **Protected-names check is non-negotiable.** If the scaffolder rejects a name, do not work around it. The check fires on both raw inputs and derived names.
+- **Tenant/subscription pin is non-negotiable.** `az account show` must match the env file's `AZURE_TENANT_ID` and `SUBSCRIPTION_ID` before any mutation.
+- **Bicep deploy-markers are cached at `deploy/.tmp/<name>/`** — wiping `.tmp/<name>/` forces full redeploys on the next run (occasionally useful for re-running a broken intermediate step, but slow).
+- **Don't propagate changes into downstream consumers.** PilotSwarm changes operate on PilotSwarm only — don't roll them into downstream app repos that vendor or consume the SDK unless the user explicitly asks.
+
+## Common Pitfalls
+
+- **`--force-module=`** with empty value: rejected at parse time (good — it would otherwise silently push an empty string and force nothing).
+- **AppGw SSL-cert not refreshing after AKV rotation**: deploy-marker skipped the portal module. Use `npm run deploy -- portal <env> --force-module portal --steps bicep`.
+- **AFD Private Endpoint approval times out**: `approve-private-endpoint.bicep` polls for up to 10 minutes. If it still times out, check `az network private-endpoint-connection list` on the PLS for stuck Pending entries.
+- **DNS prop delays on AFD**: AFD endpoint propagation can take 5–15 minutes after `global-infra`. Don't assume the curl works immediately after `all` returns; retry over ~15 minutes. During that window, `curl https://<afd-host>/api/health` will return HTTP 404 with an `x-azure-ref` header — this is normal, not a failure.
+- **Portal sign-in loop after deploy**: redirect URI on the Entra app reg doesn't match the deployed AFD endpoint. Run `az ad app show --id <clientId> --query "spa.redirectUris"` and compare. If the app was created before the AFD endpoint was known, re-run `pilotswarm-portal-app-reg` in `-ExistingAppId` append mode.
+
+## Boundary with sibling skills
+
+| Question | Skill |
+|---|---|
+| "Set up a new sandbox env" | **this skill** (`deploy.mjs`) |
+| "Roll out a fix to the existing legacy cluster" | `pilotswarm-aks-deploy` (`deploy-aks.sh`) |
+| "Reset / wipe DB on the existing cluster" | `pilotswarm-aks-reset` |
+| "Force AppGw cert refresh in my sandbox" | **this skill** (`--force-module portal`) |
+| "Provision Entra app reg for a portal stamp" | `pilotswarm-portal-app-reg` |
+| "Add a new module to the deploy" | both — the orchestrator (`deploy.mjs` services-manifest) is shaped by this skill; legacy k8s manifests live in `pilotswarm-aks-deploy` territory |

--- a/.github/skills/pilotswarm-portal-app-reg/SKILL.md
+++ b/.github/skills/pilotswarm-portal-app-reg/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: pilotswarm-portal-app-reg
+description: "Use when bringing up a PilotSwarm portal stamp with `PORTAL_AUTH_PROVIDER=entra` and no existing `PORTAL_AUTH_ENTRA_CLIENT_ID`. Drives the Entra app-registration step (create app, configure redirect URIs, optionally define app roles + require assignment, capture tenant/client IDs). Skip entirely for `PORTAL_AUTH_PROVIDER=none` or when a client ID is already supplied."
+---
+
+# pilotswarm-portal-app-reg
+
+Drives the Entra app-registration step for a PilotSwarm portal stamp.
+
+This skill is **optional** — only invoke it when the user wants
+`PORTAL_AUTH_PROVIDER=entra` AND does not already have a
+`PORTAL_AUTH_ENTRA_CLIENT_ID` to plug in. For `PORTAL_AUTH_PROVIDER=none`
+(open sandbox), skip the whole skill.
+
+## When to use this skill
+
+| User signal | Use this skill? |
+|---|---|
+| "set up entra auth for a new stamp" / "I need a client id" / new stamp with no opinion on auth wiring | **YES — create new (default recommendation)** |
+| "add a new stamp to the existing app" / mentions sharing a client id / wants single SSO consent across stamps | YES — `-ExistingAppId` mode |
+| "production stamp, lock down access" / "only certain people should sign in" / smoke-testing the role-driven authz | YES — create new with `-CreateAppRoles -AssignmentRequired` |
+| "skip auth" / "open sandbox" / `PORTAL_AUTH_PROVIDER=none` | NO — skip entirely |
+| User already pasted a `PORTAL_AUTH_ENTRA_CLIENT_ID` | NO — that value flows straight through to deploy |
+
+**Default posture: one dedicated app per stamp.** Recommend the
+create-new path unless the user explicitly asks to share an existing
+app. Per-stamp apps keep redirect URI lists short, make environment
+teardown a single `az ad app delete`, and isolate consent / revocation
+blast radius. The script auto-derives a friendly, env-specific display
+name (`"PilotSwarm Portal - <EnvName>"`) from `-EnvName` — do not
+override unless the user asks.
+
+The deployer agent **must decide the auth posture before opening the
+new-env defaults table**, because the value of
+`PORTAL_AUTH_ENTRA_CLIENT_ID` depends on the outcome.
+
+## Service Tree ID is required (no default)
+
+`Setup-PortalAuth.ps1` requires `-ServiceTreeId` as a mandatory
+parameter. Microsoft tenant policy rejects app registrations without a
+valid `serviceManagementReference`, so the script does too.
+
+Before invoking, ask the user for their Service Tree ID. If they don't
+have one registered for their PilotSwarm deployment, stop and direct
+them to register one — the tenant will reject `az ad app create`
+otherwise. Do **not** invent a placeholder GUID.
+
+## Underlying tooling
+
+| Script | Path | Purpose |
+|---|---|---|
+| `Setup-PortalAuth.ps1` | `deploy/scripts/auth/` | Opinionated wrapper that produces the exact SPA-shaped app reg the portal expects |
+| `Create3PApplication.ps1` | `deploy/scripts/auth/` | Generic Azure AD app primitive (reference; not used by the wrapper) |
+| `README.md` | `deploy/scripts/auth/` | Operator docs |
+
+The wrapper bakes in:
+- `signInAudience: AzureADMyOrg`
+- `serviceManagementReference: <-ServiceTreeId>` (operator-supplied)
+- SPA platform (no Web reply URLs)
+- `implicitGrantSettings`: id-token + access-token issuance ON
+- MS Graph delegated permissions: `User.Read` + `GroupMember.Read.All`
+- `groups` optional claim on `idToken`, `accessToken`, `saml2Token` with Default formatting
+- Owner = signed-in user
+- Service principal created
+
+Optional (off by default, opt-in with switches):
+- `-CreateAppRoles` defines two app roles (`admin`, `user`) that the
+  portal's role-driven authorization engine reads from the access token
+  (see `packages/portal/auth/authz/engine.js`)
+- `-AssignmentRequired` sets `appRoleAssignmentRequired=true` on the
+  service principal so only users/groups explicitly assigned to the app
+  can obtain a token
+
+These bakes are NOT user-configurable — they are the contract the
+PilotSwarm portal depends on. The script's parameters only cover the
+things that vary per invocation.
+
+## Discovery (run before showing the table)
+
+```bash
+az account show --query "{tenant:tenantId, user:user.name, userObjectId:id}" -o json
+```
+
+- `tenant` → user's current tenant (used as `PORTAL_AUTH_ENTRA_TENANT_ID`)
+- `user` → suggested display-name suffix and known to the operator
+- The wrapper itself derives the owner objectId via `az ad signed-in-user show`,
+  but surface the UPN so the user knows whose name will be on the app
+
+If the user provided an `EnvName` (stamp name) and a bicep-output cache
+exists, also surface the resolved redirect URI:
+
+```bash
+# Path: deploy/envs/<env>/bicep-outputs.cache.json
+# Look for: portalFqdn | afdEndpointHostname | portalUrl | PORTAL_FQDN
+```
+
+## Present the full input surface upfront
+
+Show every parameter in a single table — same UX contract as
+`pilotswarm-new-env-deploy`. Mark each value `(default)`, `(discovered)`,
+`(required)`, or `(suggested)`:
+
+```
+Mode
+  mode                     create-new (default)        # create-new | add-redirect-to-existing
+
+Identity
+  ServiceTreeId            <required: no default>
+  DisplayName              <suggested: "PilotSwarm Portal - ${EnvName}">
+  Owner                    <discovered: ${userObjectId} (${user})>
+  SkipGroupsClaim          false (default)             # keep groups claim ON for PORTAL_AUTH_ENTRA_*_GROUPS
+
+Role-driven authz (recommended for prod stamps)
+  CreateAppRoles           false (default)             # add 'admin' + 'user' app roles
+  AssignmentRequired       false (default)             # require explicit assignment to obtain a token
+
+Redirect URI (mode=create-new only)
+  EnvName                  <required-or-pick-one>
+  RedirectUri              <auto-discover from EnvName, OR ask user explicitly>
+                           # leave both empty to create app shell first, add URI later
+
+Existing app (mode=add-redirect-to-existing)
+  ExistingAppId            <required for this mode>
+  RedirectUri              <required for this mode>
+
+Output
+  OutputFile               deploy/envs/${EnvName}/entra-app.json (default when EnvName given)
+```
+
+State the chosen mode explicitly to the user before invoking. Confirm
+before running — this WRITES to Entra and creates a permanent app reg.
+
+## Decide app-role posture before invoking
+
+There are three meaningful postures for a portal stamp; pick one with
+the user:
+
+| Posture | Switches | Who can sign in | Who gets the `admin` role | When to use |
+|---|---|---|---|---|
+| **Open** | neither | Any tenant user | Nobody (all signed-in users get `PORTAL_AUTHZ_DEFAULT_ROLE`, typically `user`) | Short-lived test stamps; pure sandbox |
+| **Roles, no lockdown** | `-CreateAppRoles` | Any tenant user | Users assigned to `admin` via Enterprise apps > Users and groups (role-less principals still sign in and fall through to `defaultRole`) | Dev stamps where you want some admins but don't need to block other tenant users |
+| **Roles + lockdown** (recommended for prod) | `-CreateAppRoles -AssignmentRequired` | Only users/groups explicitly assigned to a role | Same as above | Production stamps where the portal should only be reachable by named individuals |
+
+The "Roles + lockdown" posture closes the gap where a tenant user with
+no role assignment still gets `defaultRole`. With
+`appRoleAssignmentRequired=true`, an unassigned principal gets a sign-in
+error from Entra before any token is issued — they never reach the
+portal at all.
+
+## Invocation
+
+Always invoke `pwsh` directly. Do not wrap through `npm` — there is no
+npm wrapper for this script intentionally (keeps the deploy npm pipeline
+focused on what's controlled by `.env`).
+
+**Shell compatibility:** the script runs identically on Windows, Linux,
+and macOS as long as PowerShell 7+ (`pwsh`) is installed. From the
+calling shell's perspective the invocation is a single `pwsh -File ...`
+token followed by named parameters — bash and pwsh handle it the same
+way. Use `\` for line continuation in bash, `` ` `` (backtick) in pwsh.
+The script uses forward-slash path separators and cross-platform pwsh
+APIs internally. See `deploy/scripts/auth/README.md` for `pwsh` install
+commands per OS.
+
+**Shell quoting pitfalls** (read before running ad-hoc pwsh from another
+shell):
+
+- Always invoke this wrapper with `-File`, never `-Command`. `-File`
+  takes a path + named params and is immune to outer-shell expansion.
+- If you must run an ad-hoc snippet (e.g. a quick version probe), the
+  outer shell — whether PowerShell, bash, or zsh — will try to expand
+  `$VAR` and backticks before pwsh ever sees them. Two safe forms:
+  - `pwsh -Version` (no script needed — preferred for version checks)
+  - `pwsh -NoProfile -Command '<single-quoted script>'` (single quotes
+    suppress outer-shell expansion in both bash and PowerShell)
+- Do **not** use `pwsh -Command "$PSVersionTable…"` from a PowerShell
+  parent — the parent evaluates `$PSVersionTable` first and passes
+  garbage to the child. The same trap applies to bash with `"$VAR"`.
+- For multi-line scripts, prefer a real `.ps1` file invoked with
+  `-File`. Inline `-Command` is for one-liners only.
+
+### Create new for a stamp (default — recommended)
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -EnvName <stamp-name>
+```
+
+`-EnvName` does double duty: it sets the display name to
+`"PilotSwarm Portal - <stamp-name>"` automatically and tells the script
+where to read/write per-stamp artifacts. Do **not** pass `-DisplayName`
+unless the user wants a non-standard name.
+
+This auto-discovers the redirect URI from
+`deploy/envs/<stamp>/bicep-outputs.cache.json` and writes a JSON summary
+to `deploy/envs/<stamp>/entra-app.json`. If the bicep cache doesn't
+exist yet (you're running BEFORE first deploy), keep `-EnvName` for the
+display name and per-stamp output path, and add `-RedirectUri` once you
+know the AFD endpoint (or omit it entirely to create the app shell now
+and append the URI after bicep runs):
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -EnvName <stamp-name> \
+  -RedirectUri "https://<predicted-afd-fqdn>"
+```
+
+### Create new for a production stamp (roles + lockdown)
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -EnvName <stamp-name> \
+  -CreateAppRoles \
+  -AssignmentRequired
+```
+
+After this completes the operator MUST:
+1. Open Entra portal > Enterprise applications > `"PilotSwarm Portal - <stamp-name>"` > Users and groups
+2. Add at least one user (themselves, usually) to the `Admin` role —
+   otherwise no one can sign in because `appRoleAssignmentRequired=true`.
+
+### Add a stamp to a shared existing app
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -ExistingAppId <appId> \
+  -EnvName <stamp-name>
+```
+
+(`-ServiceTreeId` is still required for parameter parsing in this mode
+but is not re-applied to the existing app.)
+
+## After the script runs
+
+The script prints two lines the user must paste somewhere:
+
+```
+PORTAL_AUTH_ENTRA_TENANT_ID = <tenantId>
+PORTAL_AUTH_ENTRA_CLIENT_ID = <new-app-id>
+```
+
+For a stamp using the npm `new-env` orchestrator, the operator paths are:
+1. **If you have NOT scaffolded the stamp yet**: hand the values to the
+   user before `new-env` runs so they go into the scaffolded `.env`
+   in the right place.
+2. **If you ALREADY scaffolded with `PORTAL_AUTH_PROVIDER=none`**: the
+   user edits `deploy/envs/<stamp>/.env` to flip provider to `entra`
+   and paste the two values, then re-runs deploy from the manifests
+   step (`node deploy/scripts/deploy.mjs portal <stamp> --steps manifests,rollout`).
+
+For the legacy bash AKS flow (`scripts/deploy-aks.sh` /
+`scripts/deploy-portal.sh`), paste the values into `.env.remote`
+(or wherever your live cluster reads portal config from) and re-run
+`./scripts/deploy-portal.sh`.
+
+The wrapper itself NEVER edits `.env` files — the operator pastes the
+values explicitly so they surface visibly.
+
+## Admin consent
+
+The `GroupMember.Read.All` delegated scope typically requires admin
+consent in the tenant. The wrapper does **not** grant consent. After
+the app is created, mention to the user:
+
+```bash
+az ad app permission admin-consent --id <new-app-id>
+```
+
+(requires tenant admin role) or direct them to the Azure portal: App
+registration → API permissions → "Grant admin consent".
+
+Without consent, sign-in still works but group claims will be empty,
+and `PORTAL_AUTH_ENTRA_ADMIN_GROUPS` / `PORTAL_AUTH_ENTRA_USER_GROUPS`
+keyed on group object IDs will not match. UPN-based admin lists
+(`PORTAL_AUTHZ_ADMIN_GROUPS`) still work without consent.
+
+## Role assignments (when -CreateAppRoles is used)
+
+After the script creates the `admin` and `user` app roles, principals
+must still be assigned. The script does NOT do this — it only defines
+the roles. Two paths:
+
+1. **Entra portal** (recommended for one-offs): Enterprise applications
+   > `"PilotSwarm Portal - <stamp>"` > Users and groups > Add
+   user/group > pick role.
+2. **Scripted** (CI / many users): `az rest` against
+   `https://graph.microsoft.com/v1.0/servicePrincipals/<sp-objectId>/appRoleAssignedTo`
+   with the principal ID, resource ID (the SP's own object ID), and
+   `appRoleId` from the entra-app.json summary.
+
+If `-AssignmentRequired` is set and no one is assigned, sign-in fails
+with `AADSTS50105: The signed in user is not assigned to a role for the
+application`. Assign the operator FIRST so they can finish setting up.
+
+## What this skill will not do
+
+- Will not write to `.env` files (operator surfaces values explicitly)
+- Will not grant admin consent (separate tenant-admin action)
+- Will not assign users to app roles (Entra portal or `az rest` after creation)
+- Will not modify the npm `new-env` / `deploy` pipelines — they
+  continue to consume `PORTAL_AUTH_ENTRA_CLIENT_ID` as plain input
+- Will not provision app registrations of non-portal shapes — for
+  worker daemons or APIs, use `Create3PApplication.ps1` directly or
+  write a new wrapper
+- Will not invent a Service Tree ID — operator must supply
+
+## Constraints
+
+- `-ServiceTreeId` is **mandatory by tenant policy** — refuse to
+  invent a placeholder
+- Never run the wrapper against a non-target tenant — the script will
+  succeed but the app will be useless to your portal
+- Never propose granting `Application.ReadWrite.All` or similar
+  high-privilege tenant scopes — `User.Read` + `GroupMember.Read.All`
+  is the full delegated-scope surface the portal needs
+- Single-tenant only by design. Multi-tenant or personal-MSA sign-in is
+  out of scope for the wrapper; use `Create3PApplication.ps1` if you
+  need a different shape

--- a/deploy/scripts/auth/Create3PApplication.ps1
+++ b/deploy/scripts/auth/Create3PApplication.ps1
@@ -1,0 +1,347 @@
+<#
+.SYNOPSIS
+    Creates an Azure AD application with configurable parameters.
+
+.DESCRIPTION
+    Generic Azure AD application primitive built on the Azure CLI. Supports:
+    - Custom display name and identifier URIs
+    - App roles and required resource access (JSON format)
+    - Optional service principal creation
+    - User/group enterprise-app assignments
+    - Comprehensive error handling and validation
+    - Security-first design: OAuth2 delegated permissions require explicit opt-in
+
+    This script is a generic primitive. For the PilotSwarm portal SPA shape
+    (single-tenant, SPA redirect URIs, implicit grant, MS Graph User.Read +
+    GroupMember.Read.All, groups optional-claim) use the wrapper
+    Setup-PortalAuth.ps1 in this directory.
+
+    The -serviceManagementReference parameter is REQUIRED by Microsoft tenant
+    policy. Supply your own Service Tree ID — there is no default.
+
+.PARAMETER displayName
+    The display name for the Azure AD application (required).
+
+.PARAMETER identifierUris
+    The identifier URIs for the application. Can be a single URI or comma-separated list.
+
+.PARAMETER requiredResourceAccess
+    JSON string defining the required resource access (API permissions).
+
+.PARAMETER appRoles
+    JSON string defining application roles.
+
+.PARAMETER groupMembershipClaims
+    Group membership claims setting. Default: "SecurityGroup"
+    Valid values: "None", "SecurityGroup", "All"
+
+.PARAMETER signInAudience
+    Default: "AzureADMyOrg"
+    Valid values: "AzureADMyOrg", "AzureADMultipleOrgs", "AzureADandPersonalMicrosoftAccount", "PersonalMicrosoftAccount"
+
+.PARAMETER owner
+    Object ID of the user to set as the application owner. Defaults to the
+    currently signed-in Azure CLI user.
+
+.PARAMETER serviceManagementReference
+    Service management reference (Service Tree ID) — REQUIRED by Microsoft
+    tenant policy. Supply the Service Tree ID registered for your service.
+
+.PARAMETER createServicePrincipal
+    Switch to also create a service principal for the application.
+
+.PARAMETER assignmentRequired
+    Switch to require assignment for users to access the application.
+
+.PARAMETER assignedUsers
+    JSON string defining users to assign to the enterprise application.
+
+.PARAMETER assignedGroups
+    JSON string defining groups to assign to the enterprise application.
+
+.PARAMETER outputFile
+    Path to save the creation results as JSON.
+
+.PARAMETER enableDelegatedAccess
+    Switch to enable OAuth2 delegated permissions (user_impersonation scope).
+
+.PARAMETER preAuthorizeAzureCLI
+    Switch to pre-authorize Azure CLI. Only effective with -enableDelegatedAccess.
+
+.PARAMETER delegatedScopeName
+    Name for the OAuth2 delegated scope. Default: "user_impersonation"
+
+.EXAMPLE
+    .\Create3PApplication.ps1 -displayName "My Enterprise App" -serviceManagementReference <your-service-tree-id>
+
+.EXAMPLE
+    .\Create3PApplication.ps1 -displayName "My API App" -identifierUris "https://myapi.contoso.com" -serviceManagementReference <your-service-tree-id> -createServicePrincipal
+
+.NOTES
+    Prerequisites:
+    - Azure CLI installed and in PATH
+    - az login completed
+    - Sufficient permissions to create Azure AD applications
+
+    Origin: generic Azure AD app primitive. Adapted for PilotSwarm.
+    Version: 1.0
+#>
+
+param(
+    [Parameter(Mandatory=$true)][string]$displayName,
+    [Parameter(Mandatory=$false)][string]$identifierUris,
+    [Parameter(Mandatory=$false)][string]$requiredResourceAccess,
+    [Parameter(Mandatory=$false)][string]$appRoles,
+    [Parameter(Mandatory=$false)][string]$groupMembershipClaims = "SecurityGroup",
+    [Parameter(Mandatory=$false)][string]$signInAudience = "AzureADMyOrg",
+    [Parameter(Mandatory=$false)][string]$owner,
+    [Parameter(Mandatory=$true)][string]$serviceManagementReference,
+    [Parameter(Mandatory=$false)][switch]$createServicePrincipal = $false,
+    [Parameter(Mandatory=$false)][switch]$assignmentRequired = $false,
+    [Parameter(Mandatory=$false)][string]$assignedUsers,
+    [Parameter(Mandatory=$false)][string]$assignedGroups,
+    [Parameter(Mandatory=$false)][string]$outputFile,
+    [Parameter(Mandatory=$false)][switch]$enableDelegatedAccess = $false,
+    [Parameter(Mandatory=$false)][switch]$preAuthorizeAzureCLI = $false,
+    [Parameter(Mandatory=$false)][string]$delegatedScopeName = "user_impersonation"
+)
+
+$AZURE_CLI_CLIENT_ID = "04b07795-8ddb-461a-bbee-02f9e1bf7b46"
+
+$enableOAuth2 = $enableDelegatedAccess
+$preAuthCLI = $preAuthorizeAzureCLI
+
+function New-OAuth2PermissionScope {
+    param([string]$DisplayName, [string]$ScopeId, [string]$ScopeName = "user_impersonation")
+    if ([string]::IsNullOrWhiteSpace($ScopeId)) { $ScopeId = [System.Guid]::NewGuid().ToString() }
+    $description = "Allows the application to access $DisplayName on behalf of the signed-in user"
+    return @{
+        adminConsentDescription = $description
+        adminConsentDisplayName = "Access $DisplayName"
+        id = $ScopeId
+        isEnabled = $true
+        type = "User"
+        userConsentDescription = "Allow the application to access $DisplayName on your behalf"
+        userConsentDisplayName = "Access $DisplayName"
+        value = $ScopeName
+    }
+}
+
+function New-PreAuthorizedApplication {
+    param([string]$ClientId, [string[]]$DelegatedPermissionIds)
+    return @{ appId = $ClientId; delegatedPermissionIds = $DelegatedPermissionIds }
+}
+
+function Set-OAuth2PermissionScopes {
+    param([string]$ApplicationObjectId, [array]$OAuth2PermissionScopes)
+    Write-Host "Configuring OAuth2 permission scopes..." -ForegroundColor Yellow
+    try {
+        $apiConfig = @{ api = @{ oauth2PermissionScopes = $OAuth2PermissionScopes } }
+        $tempFile = [System.IO.Path]::GetTempFileName()
+        ($apiConfig | ConvertTo-Json -Depth 5 -Compress) | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+        $updateResult = az rest --method PATCH --uri "https://graph.microsoft.com/v1.0/applications/$ApplicationObjectId" --headers "Content-Type=application/json" --body "@$tempFile"
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Added OAuth2 permission scope: $($OAuth2PermissionScopes[0].value)" -ForegroundColor Green
+            return $true
+        }
+        Write-Warning "Failed to configure OAuth2 permission scopes. Output: $updateResult"
+        return $false
+    } catch {
+        Write-Warning "Error configuring OAuth2 permission scopes: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Set-PreAuthorizedApplications {
+    param([string]$ApplicationObjectId, [array]$PreAuthorizedApplications)
+    Write-Host "Configuring pre-authorized applications..." -ForegroundColor Yellow
+    try {
+        Start-Sleep -Seconds 2
+        $apiConfig = @{ api = @{ preAuthorizedApplications = $PreAuthorizedApplications } }
+        $tempFile = [System.IO.Path]::GetTempFileName()
+        ($apiConfig | ConvertTo-Json -Depth 5 -Compress) | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+        $updateResult = az rest --method PATCH --uri "https://graph.microsoft.com/v1.0/applications/$ApplicationObjectId" --headers "Content-Type=application/json" --body "@$tempFile"
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  Pre-authorized Azure CLI for seamless authentication" -ForegroundColor Green
+            return $true
+        }
+        Write-Warning "Failed to configure pre-authorized applications. Output: $updateResult"
+        return $false
+    } catch {
+        Write-Warning "Error configuring pre-authorized applications: $($_.Exception.Message)"
+        return $false
+    }
+}
+
+function Test-JsonInput {
+    param([string]$jsonString, [string]$parameterName)
+    if ([string]::IsNullOrWhiteSpace($jsonString)) { return $true }
+    try { $null = ConvertFrom-Json $jsonString -ErrorAction Stop; return $true }
+    catch { Write-Error "Invalid JSON format for parameter '$parameterName': $jsonString"; return $false }
+}
+
+function Test-AzureCliReady {
+    try {
+        $null = az version 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Error "Azure CLI is not installed or not available in PATH"; return $false }
+        $null = az account show 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Error "Not logged in to Azure CLI. Please run 'az login' first"; return $false }
+        return $true
+    } catch { Write-Error "Error checking Azure CLI status: $_"; return $false }
+}
+
+Write-Host "Starting Azure AD Application creation process..." -ForegroundColor Green
+
+if (-not (Test-AzureCliReady)) { throw "Azure CLI is not ready." }
+
+$validationFailed = $false
+if (-not (Test-JsonInput -jsonString $requiredResourceAccess -parameterName "requiredResourceAccess")) { $validationFailed = $true }
+if (-not (Test-JsonInput -jsonString $appRoles -parameterName "appRoles")) { $validationFailed = $true }
+if (-not (Test-JsonInput -jsonString $assignedUsers -parameterName "assignedUsers")) { $validationFailed = $true }
+if (-not (Test-JsonInput -jsonString $assignedGroups -parameterName "assignedGroups")) { $validationFailed = $true }
+if ($validationFailed) { throw "Parameter validation failed." }
+
+Write-Host "Getting current Azure user..." -ForegroundColor Yellow
+try {
+    $currentUser = az ad signed-in-user show --query "id" -o tsv
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($currentUser)) {
+        Write-Warning "Could not retrieve current user ID."
+        $currentUser = $null
+    } else {
+        Write-Host "Current user ID: $currentUser" -ForegroundColor Green
+    }
+    if ([string]::IsNullOrWhiteSpace($owner) -and $currentUser) { $owner = $currentUser }
+} catch {
+    Write-Warning "Failed to get current user: $($_.Exception.Message)"
+    $currentUser = $null
+}
+Write-Host ""
+
+$appCreationResult = $null
+$servicePrincipalResult = $null
+
+try {
+    Write-Host "Creating Azure AD application '$displayName'..." -ForegroundColor Yellow
+    $tempFiles = @()
+    try {
+        $arguments = @("ad", "app", "create", "--display-name", $displayName)
+
+        if (-not [string]::IsNullOrWhiteSpace($identifierUris)) {
+            $arguments += "--identifier-uris", $identifierUris
+        }
+        if (-not [string]::IsNullOrWhiteSpace($requiredResourceAccess)) {
+            $tempFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $tempFile
+            $requiredResourceAccess | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+            $arguments += "--required-resource-access", "@$tempFile"
+        }
+        if (-not [string]::IsNullOrWhiteSpace($appRoles)) {
+            $tempFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $tempFile
+            $appRoles | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+            $arguments += "--app-roles", "@$tempFile"
+        }
+        $arguments += "--service-management-reference", $serviceManagementReference
+        $arguments += "--sign-in-audience", $signInAudience
+        if (-not [string]::IsNullOrWhiteSpace($groupMembershipClaims)) {
+            $tempFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $tempFile
+            '{"idToken": [], "accessToken": [], "saml2Token": []}' | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+            $arguments += "--optional-claims", "@$tempFile"
+        }
+
+        $appCreationOutput = az @arguments
+    } finally {
+        foreach ($tempFile in $tempFiles) { if (Test-Path $tempFile) { Remove-Item $tempFile -Force -ErrorAction SilentlyContinue } }
+    }
+
+    if ($LASTEXITCODE -ne 0) { throw "Azure AD application creation failed. Output: $appCreationOutput" }
+
+    $appCreationResult = $appCreationOutput | ConvertFrom-Json
+    $appId = $appCreationResult.appId
+    $objectId = $appCreationResult.id
+    Write-Host "Successfully created Azure AD application!" -ForegroundColor Green
+    Write-Host "Application ID: $appId" -ForegroundColor Green
+    Write-Host "Object ID: $objectId" -ForegroundColor Green
+
+    if ($enableOAuth2) {
+        Write-Host "Configuring OAuth2 delegated permissions..." -ForegroundColor Yellow
+        $scopeId = [System.Guid]::NewGuid().ToString()
+        $oauth2Scopes = @(New-OAuth2PermissionScope -DisplayName $displayName -ScopeId $scopeId -ScopeName $delegatedScopeName)
+        $preAuthorizedApps = @()
+        if ($preAuthCLI) {
+            $preAuthorizedApps += New-PreAuthorizedApplication -ClientId $AZURE_CLI_CLIENT_ID -DelegatedPermissionIds @($scopeId)
+        }
+        $scopeConfigSuccess = Set-OAuth2PermissionScopes -ApplicationObjectId $objectId -OAuth2PermissionScopes $oauth2Scopes
+        $preAuthSuccess = $true
+        if ($preAuthorizedApps.Count -gt 0) {
+            $preAuthSuccess = Set-PreAuthorizedApplications -ApplicationObjectId $objectId -PreAuthorizedApplications $preAuthorizedApps
+        }
+        if ($scopeConfigSuccess -and $preAuthSuccess) { Write-Host "OAuth2 delegated access configured" -ForegroundColor Green }
+        elseif ($scopeConfigSuccess) { Write-Host "OAuth2 scopes configured (pre-auth may need manual setup)" -ForegroundColor Yellow }
+        else { Write-Warning "OAuth2 configuration failed." }
+    }
+
+    if (-not [string]::IsNullOrWhiteSpace($owner)) {
+        Write-Host "Setting application owner..." -ForegroundColor Yellow
+        try {
+            $ownerSetOutput = az ad app owner add --id $appId --owner-object-id $owner
+            if ($LASTEXITCODE -eq 0) { Write-Host "Successfully set application owner: $owner" -ForegroundColor Green }
+            else { Write-Warning "Failed to set application owner. Output: $ownerSetOutput" }
+        } catch { Write-Warning "Failed to set application owner: $($_.Exception.Message)" }
+    }
+
+    if ($createServicePrincipal) {
+        Write-Host "Creating service principal..." -ForegroundColor Yellow
+        $spCreationOutput = az ad sp create --id $appId
+        if ($LASTEXITCODE -ne 0) {
+            Write-Warning "Service principal creation failed. Output: $spCreationOutput"
+        } else {
+            $servicePrincipalResult = $spCreationOutput | ConvertFrom-Json
+            $spObjectId = $servicePrincipalResult.id
+            Write-Host "Successfully created service principal: $spObjectId" -ForegroundColor Green
+            if ($assignmentRequired) {
+                Write-Host "Setting assignment requirement to true..." -ForegroundColor Yellow
+                $null = az ad sp update --id $spObjectId --set appRoleAssignmentRequired=true
+                if ($LASTEXITCODE -eq 0) { Write-Host "Enabled assignment requirement" -ForegroundColor Green }
+                else { Write-Warning "Failed to set assignment requirement." }
+            }
+        }
+    }
+
+    $result = @{
+        ApplicationId = $appId
+        ApplicationObjectId = $objectId
+        DisplayName = $displayName
+        CreatedDateTime = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssZ")
+        Status = "Success"
+    }
+    if ($servicePrincipalResult) {
+        $result.ServicePrincipalObjectId = $servicePrincipalResult.id
+        $result.ServicePrincipalAppId = $servicePrincipalResult.appId
+    }
+    if (-not [string]::IsNullOrWhiteSpace($outputFile)) {
+        $result | ConvertTo-Json -Depth 3 | Out-File -FilePath $outputFile -Encoding UTF8
+        Write-Host "Results saved to: $outputFile" -ForegroundColor Green
+    }
+
+    Write-Host "`n=== Application Creation Summary ===" -ForegroundColor Green
+    Write-Host "Display Name: $($result.DisplayName)"
+    Write-Host "Application ID: $($result.ApplicationId)"
+    Write-Host "Object ID: $($result.ApplicationObjectId)"
+    if ($result.ServicePrincipalObjectId) { Write-Host "Service Principal Object ID: $($result.ServicePrincipalObjectId)" }
+    Write-Host "Created: $($result.CreatedDateTime)"
+    Write-Host "=================================" -ForegroundColor Green
+
+    return $appId
+} catch {
+    Write-Error "An error occurred while creating the Azure AD application: $_"
+    Write-Host $_.ScriptStackTrace -ForegroundColor Red
+    if ($appCreationResult -and $appCreationResult.appId) {
+        Write-Host "Attempting cleanup of partially created application..." -ForegroundColor Yellow
+        try {
+            az ad app delete --id $appCreationResult.appId
+            if ($LASTEXITCODE -eq 0) { Write-Host "Cleanup completed" -ForegroundColor Green }
+        } catch { Write-Warning "Failed to cleanup application $($appCreationResult.appId): $_" }
+    }
+    throw "Azure AD application creation failed: $_"
+}

--- a/deploy/scripts/auth/README.md
+++ b/deploy/scripts/auth/README.md
@@ -1,0 +1,184 @@
+# PilotSwarm Portal — Entra app registration scripts
+
+PowerShell helpers for provisioning the Azure AD app registration that backs
+`PORTAL_AUTH_PROVIDER=entra` on a PilotSwarm portal stamp.
+
+These scripts are **not** wired into `npm run deploy` or the legacy
+`scripts/deploy-aks.sh` flow. The deploy flows still consume
+`PORTAL_AUTH_ENTRA_CLIENT_ID` as an input from your stamp's `.env` /
+`.env.remote`. Run the wrapper here first, copy the printed client ID
+into the env, then run deploy.
+
+The agent / skill driving PilotSwarm npm deployments will offer to run
+this for you (see `.github/skills/pilotswarm-portal-app-reg/SKILL.md`).
+You can also invoke it directly.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Create3PApplication.ps1` | Generic Azure AD application primitive. Useful if you need a non-portal app registration (e.g. a worker daemon with app roles). The PilotSwarm portal wrapper does **not** call this — it does its own SPA-shaped `az ad app create` so it can configure the SPA platform + implicit-grant + per-token-type groups claim, which the generic primitive doesn't expose. |
+| `Setup-PortalAuth.ps1` | Opinionated wrapper that creates the exact shape the PilotSwarm portal expects. See "Defaults" below. |
+
+## Prerequisites
+
+- Azure CLI installed and on PATH
+- PowerShell 7+ (`pwsh`) installed — these scripts run on **Windows, Linux, and macOS**.
+  - Windows: install `pwsh` (PS 7) from <https://aka.ms/PowerShell>. Both `powershell.exe` (5.1) and `pwsh` (7) work; PS 7 is preferred.
+  - macOS: `brew install --cask powershell`
+  - Linux: see <https://learn.microsoft.com/powershell/scripting/install/installing-powershell-on-linux>
+- `az login` completed as a user in the target tenant with permission to
+  create application registrations (typically the "Application Developer"
+  Entra role or higher).
+- For `-EnvName` auto-discovery: the stamp's
+  `deploy/envs/<EnvName>/bicep-outputs.cache.json` must exist (i.e. the
+  bicep-publish step of `npm run deploy` has run at least once).
+
+The scripts use only cross-platform pwsh APIs (`Join-Path`, `Resolve-Path`,
+`[System.IO.Path]::GetTempFileName()`, `az`) and forward-slash path
+separators throughout, so the same invocation works in all three OSes.
+
+## Service Tree ID is required
+
+Microsoft tenant policy requires every app registration to carry a valid
+`serviceManagementReference` (Service Tree ID). `Setup-PortalAuth.ps1`
+requires `-ServiceTreeId` as a mandatory parameter — **there is no
+default**. Supply the Service Tree ID registered for your service.
+
+If your organization does not yet have a Service Tree entry for the
+PilotSwarm deployment, register one before running these scripts. The
+tenant will reject `az ad app create` without a recognized value.
+
+## Defaults (baked into Setup-PortalAuth.ps1)
+
+| Setting | Value | Why |
+|---------|-------|-----|
+| `signInAudience` | `AzureADMyOrg` | Single-tenant (your tenant only) |
+| `serviceManagementReference` | from `-ServiceTreeId` (required) | Tenant policy requires it |
+| Platform | SPA (Single-page application) | Portal is a browser SPA using MSAL |
+| `web.implicitGrantSettings.enableIdTokenIssuance` | `true` | Matches portal MSAL config |
+| `web.implicitGrantSettings.enableAccessTokenIssuance` | `true` | Matches portal MSAL config |
+| MS Graph delegated scopes | `User.Read` + `GroupMember.Read.All` | User.Read for sign-in; GroupMember.Read.All so groups optional-claim can populate |
+| Optional `groups` claim | `idToken`, `accessToken`, `saml2Token` | Required for group-based admin/user role mapping (`PORTAL_AUTH_ENTRA_ADMIN_GROUPS`, `PORTAL_AUTH_ENTRA_USER_GROUPS`) |
+| App roles (`-CreateAppRoles`) | optional `admin` + `user` (allowedMemberTypes=["User"]) | Read by `packages/portal/auth/authz/engine.js` — assign principals via "Enterprise applications > Users and groups" |
+| `appRoleAssignmentRequired` (`-AssignmentRequired`) | optional, `true` when set | Blocks unassigned users from getting a token at all |
+| Identifier URIs | none | Not an API |
+| Service principal | created | Needed for tenant consent + role assignments |
+| Owner | current signed-in user | Override with `-Owner <objectId>` |
+
+## Common usage
+
+All examples below run identically in **bash** (Linux/macOS) and **pwsh**
+(any OS), because `pwsh -File <script>` is a single token from the
+parent shell's perspective and all named parameters can be passed on
+one line. Inside the script everything is pwsh.
+
+If you want to break a long invocation across multiple lines, use the
+line-continuation char native to your shell: `\` in bash, `` ` ``
+(backtick) in pwsh.
+
+### Production stamp (recommended posture)
+
+```bash
+# From repo root, any OS. Replace <your-service-tree-id> with your real ID.
+pwsh -NoProfile -ExecutionPolicy Bypass \
+  -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -EnvName prodstamp \
+  -CreateAppRoles \
+  -AssignmentRequired
+```
+
+- Creates `"PilotSwarm Portal - prodstamp"`
+- Defines `admin` and `user` app roles (assignable from "Users and groups")
+- Sets `appRoleAssignmentRequired=true` on the SP — only explicitly
+  assigned users/groups can obtain a token
+- Auto-discovers redirect URI from `deploy/envs/prodstamp/bicep-outputs.cache.json`
+- Writes `{ tenantId, clientId, objectId, redirectUri }` to `deploy/envs/prodstamp/entra-app.json`
+- Prints env-var lines to paste into the stamp's `.env`
+
+After the script: assign at least one user to `admin` (so you can sign in)
+and grant admin consent for `GroupMember.Read.All`.
+
+### Sandbox stamp (no role gating)
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass \
+  -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -EnvName mystamp
+```
+
+- Same shape but no app roles, no `appRoleAssignmentRequired`
+- Any user in the tenant can sign in
+- `PORTAL_AUTHZ_DEFAULT_ROLE` (typically `user`) decides the role of
+  every signed-in principal
+
+### Share one app across multiple stamps
+
+If you have an existing app reg and just want to add a new stamp's
+redirect URI to it:
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass \
+  -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -ExistingAppId <existing-app-id> \
+  -EnvName mystamp
+```
+
+This appends the stamp's AFD endpoint to the existing app's SPA redirect
+URI list (deduped) — no other modifications. `-ServiceTreeId` is still
+required for parameter parsing but is not re-applied to the existing app.
+
+### Pre-deploy creation (no redirect URI yet)
+
+```bash
+pwsh -NoProfile -ExecutionPolicy Bypass \
+  -File deploy/scripts/auth/Setup-PortalAuth.ps1 \
+  -ServiceTreeId <your-service-tree-id> \
+  -DisplayName "PilotSwarm Portal - newstamp"
+```
+
+Creates the app shell with the correct policy/permissions/claims but
+with an empty redirect-URI list. After deploy finishes, run again with
+`-ExistingAppId <newAppId> -EnvName newstamp` to add the discovered URI.
+
+## What this script will NOT do
+
+- Will not write to `.env` files — you must paste `PORTAL_AUTH_ENTRA_CLIENT_ID`
+  yourself (so secrets surface explicitly).
+- Will not grant admin consent. Group-membership-based scopes
+  (`GroupMember.Read.All`) typically require admin consent in the tenant. The
+  operator workflow is: create app, then a tenant admin clicks "Grant
+  admin consent" in the portal **or** runs:
+  ```
+  az ad app permission admin-consent --id <clientId>
+  ```
+- Will not assign users to app roles. Use the Entra portal
+  ("Enterprise applications > <app> > Users and groups > Add user/group")
+  or `az ad app permission` / `az rest` for scripted assignments.
+- Will not configure `PORTAL_AUTH_ENTRA_ADMIN_ROLE`, `PORTAL_AUTH_ENTRA_USER_ROLE`,
+  or the `PORTAL_AUTHZ_*` env vars — those are deploy-time inputs to
+  the portal `.env`.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `Insufficient privileges to complete the operation` on `az ad app create` | Account is missing the "Application Developer" role or higher in Entra | Have an Entra admin grant the role, or run as someone who has it |
+| `Service tree ID is not valid` / tenant policy rejection | `-ServiceTreeId` not registered in your tenant's Service Tree | Register a Service Tree entry for the PilotSwarm deployment, then re-run with the registered GUID |
+| `az ad signed-in-user show` returns empty | You ran `az login --identity` (managed identity) or service-principal login | Run the script under an interactive `az login` user account |
+| Portal still shows "sign in" loop after deploy | Most often: redirect URI on the app reg doesn't match the deployed AFD endpoint exactly | Run `az ad app show --id <clientId> --query "spa.redirectUris"` and compare against your portal's `https://` root |
+| Group claims missing from access token | Group claim was not added, OR admin consent for `GroupMember.Read.All` was not granted | Re-run the script (it will idempotently re-apply optional claims) and grant admin consent |
+| Signed-in user with no role gets `defaultRole` instead of being denied | `-AssignmentRequired` was NOT set, so any tenant user can sign in even without an app-role assignment | Re-run with `-AssignmentRequired` (or set it manually: `az ad sp update --id <sp-objectId> --set appRoleAssignmentRequired=true`) |
+| `403` on portal admin routes | Signed-in user does not have the `admin` app role (or matching group via `PORTAL_AUTH_ENTRA_ADMIN_GROUPS`) | Assign the user to the `admin` role in "Enterprise applications > Users and groups" |
+
+## Why `Create3PApplication.ps1` is included
+
+`Create3PApplication.ps1` is a generic Azure AD app primitive included
+for completeness — future scripts that need a non-portal-shaped app
+registration (e.g. a worker daemon with app-roles, a confidential
+client) can use it directly. The PilotSwarm portal wrapper does not
+call it because the portal needs SPA-specific Graph PATCH calls that
+the generic primitive doesn't perform.

--- a/deploy/scripts/auth/Setup-PortalAuth.ps1
+++ b/deploy/scripts/auth/Setup-PortalAuth.ps1
@@ -1,0 +1,506 @@
+<#
+.SYNOPSIS
+    Creates (or updates) the Entra app registration for a PilotSwarm portal stamp.
+
+.DESCRIPTION
+    Opinionated wrapper that produces the exact app-registration shape the
+    PilotSwarm portal expects when PORTAL_AUTH_PROVIDER=entra:
+
+    - signInAudience: AzureADMyOrg (single-tenant)
+    - serviceManagementReference: supplied via -ServiceTreeId (REQUIRED — no default)
+    - SPA platform (no Web reply URLs); redirect URI is the portal's https:// root
+    - implicitGrantSettings: idToken + accessToken issuance enabled
+    - MS Graph delegated permissions: User.Read + GroupMember.Read.All
+    - Optional 'groups' claim on idToken, accessToken, and saml2Token
+    - App roles (admin / user) — assignable to Users; created when -CreateAppRoles is set
+    - Owner: current signed-in Azure CLI user (override with -Owner)
+    - Service principal created by default (needed for tenant consent + assignments)
+    - -AssignmentRequired sets appRoleAssignmentRequired=true on the SP so
+      only users/groups explicitly assigned to the app can obtain a token
+
+    The redirect URI for a stamp is the AFD endpoint (or AppGw FQDN) the
+    portal is served from. You can either:
+
+    1) Pass -RedirectUri https://my-portal.example.com  (explicit)
+    2) Pass -EnvName <stamp-name>                       (auto-discovers from
+       deploy/envs/<stamp>/bicep-outputs.cache.json — requires deploy to
+       have run at least through the bicep-publish step)
+    3) Pass neither and the app will be created without a redirect URI; you
+       can add one later with -ExistingAppId once you know the endpoint.
+
+    The script supports BOTH modes:
+    - "Create a new app" (default)
+    - "Add a redirect URI to an existing app" via -ExistingAppId — this is
+      the typical pattern when one app reg serves multiple stamps.
+
+.PARAMETER ServiceTreeId
+    REQUIRED. Service Tree ID for your service, written as the
+    serviceManagementReference on the app registration. Microsoft tenant
+    policy requires every app registration to carry a valid Service Tree
+    reference. There is intentionally no default — supply your own.
+
+.PARAMETER DisplayName
+    Display name for the app registration. Default: "PilotSwarm Portal - <EnvName>"
+    or "PilotSwarm Portal" if EnvName is not provided.
+
+.PARAMETER EnvName
+    Stamp name (e.g. mystamp). When provided:
+    - Used to derive the default DisplayName.
+    - Used to auto-discover the AFD endpoint from
+      deploy/envs/<EnvName>/bicep-outputs.cache.json if -RedirectUri is not given.
+
+.PARAMETER RedirectUri
+    Explicit SPA redirect URI (https://...). Overrides EnvName auto-discovery.
+
+.PARAMETER ExistingAppId
+    If provided, the script will NOT create a new app. Instead it appends
+    the resolved redirect URI to the existing app's spa.redirectUris list
+    (deduplicated). Useful for sharing one app reg across many stamps.
+
+.PARAMETER Owner
+    Object ID of the user to set as application owner. Defaults to the
+    currently signed-in Azure CLI user.
+
+.PARAMETER SkipGroupsClaim
+    If set, do NOT add the 'groups' optional claim. Default is to include it
+    so PORTAL_AUTH_ENTRA_*_GROUPS env vars can match against group object IDs
+    in the token.
+
+.PARAMETER CreateAppRoles
+    If set, defines two app roles ('admin' and 'user') on the app registration.
+    These are the roles the portal's role-driven authorization engine
+    (packages/portal/auth/authz/engine.js) reads from the access token. After
+    creation, assign users/groups to these roles via:
+      - Entra portal: Enterprise applications > <app> > Users and groups
+      - or `az ad sp app-role-assignment` (advanced)
+
+.PARAMETER AssignmentRequired
+    If set, configures the service principal with appRoleAssignmentRequired=true,
+    which blocks any user not explicitly assigned (directly or via a group) to
+    the app from obtaining a token. Recommended in combination with
+    -CreateAppRoles for production stamps where only assigned users + roles
+    should reach the portal at all.
+
+.PARAMETER OutputFile
+    Path to write a JSON summary { tenantId, clientId, objectId, redirectUri }.
+    Defaults to deploy/envs/<EnvName>/entra-app.json when EnvName is provided.
+
+.EXAMPLE
+    .\Setup-PortalAuth.ps1 -ServiceTreeId <your-service-tree-id> -EnvName mystamp
+
+    Creates a new app named "PilotSwarm Portal - mystamp", auto-discovers
+    the redirect URI from deploy/envs/mystamp/bicep-outputs.cache.json, and
+    writes the resulting clientId to deploy/envs/mystamp/entra-app.json.
+
+.EXAMPLE
+    .\Setup-PortalAuth.ps1 -ServiceTreeId <your-service-tree-id> `
+        -DisplayName "PilotSwarm Portal" `
+        -RedirectUri "https://my-portal.example.com"
+
+    Creates a new app with an explicit redirect URI (no env-name).
+
+.EXAMPLE
+    .\Setup-PortalAuth.ps1 -ServiceTreeId <your-service-tree-id> `
+        -EnvName prodstamp -CreateAppRoles -AssignmentRequired
+
+    Creates a new app with 'admin' and 'user' app roles AND sets
+    appRoleAssignmentRequired=true on the service principal. Only users
+    explicitly assigned to one of the roles can sign in. This is the
+    recommended posture for production stamps consuming the role-driven
+    authorization engine (PORTAL_AUTH_ENTRA_ADMIN_ROLE/USER_ROLE).
+
+.EXAMPLE
+    .\Setup-PortalAuth.ps1 -ServiceTreeId <your-service-tree-id> `
+        -ExistingAppId e4a81386-accc-48d5-b7d8-9f3324aec1e6 `
+        -EnvName newstamp
+
+    Adds the newstamp's AFD endpoint as a new SPA redirect URI on the
+    existing shared app.
+
+.NOTES
+    Prerequisites:
+    - Azure CLI installed and logged in (az login) as a tenant member with
+      permission to create/modify Azure AD applications.
+    - For -EnvName auto-discovery: bicep-outputs.cache.json must exist for
+      that stamp.
+
+    Outputs:
+    - JSON summary file (see -OutputFile).
+    - Stdout summary block including the value for PORTAL_AUTH_ENTRA_CLIENT_ID.
+
+    This wrapper is intentionally NOT wired into the npm deploy pipeline. The
+    deploy scripts still take PORTAL_AUTH_ENTRA_CLIENT_ID as input from .env.
+    Run this wrapper first, copy the printed clientId into your stamp's .env,
+    then proceed with deploy.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory=$true)][string]$ServiceTreeId,
+    [Parameter(Mandatory=$false)][string]$DisplayName,
+    [Parameter(Mandatory=$false)][string]$EnvName,
+    [Parameter(Mandatory=$false)][string]$RedirectUri,
+    [Parameter(Mandatory=$false)][string]$ExistingAppId,
+    [Parameter(Mandatory=$false)][string]$Owner,
+    [Parameter(Mandatory=$false)][switch]$SkipGroupsClaim = $false,
+    [Parameter(Mandatory=$false)][switch]$CreateAppRoles = $false,
+    [Parameter(Mandatory=$false)][switch]$AssignmentRequired = $false,
+    [Parameter(Mandatory=$false)][string]$OutputFile
+)
+
+$ErrorActionPreference = "Stop"
+
+# MS Graph constants (well-known and stable)
+$MS_GRAPH_RESOURCE_APP_ID = "00000003-0000-0000-c000-000000000000"
+$MS_GRAPH_USER_READ_SCOPE_ID = "e1fe6dd8-ba31-4d61-89e7-88639da4683d"
+$MS_GRAPH_GROUPMEMBER_READ_ALL_SCOPE_ID = "bc024368-1153-4739-b217-4326f2e966d0"
+
+function Test-AzureCliReady {
+    try {
+        $null = az version 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Error "Azure CLI is not installed or not in PATH"; return $false }
+        $null = az account show 2>$null
+        if ($LASTEXITCODE -ne 0) { Write-Error "Not logged in. Run 'az login' first."; return $false }
+        return $true
+    } catch { Write-Error "Error checking az CLI: $_"; return $false }
+}
+
+function Get-RepoRoot {
+    return (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
+}
+
+function Resolve-RedirectUriFromEnv {
+    param([string]$Env)
+    $repo = Get-RepoRoot
+    $cache = Join-Path $repo "deploy/envs/$Env/bicep-outputs.cache.json"
+    if (-not (Test-Path $cache)) {
+        Write-Warning "bicep-outputs.cache.json not found at $cache - cannot auto-discover redirect URI."
+        return $null
+    }
+    try {
+        $outputs = Get-Content $cache -Raw | ConvertFrom-Json
+    } catch {
+        Write-Warning "Failed to parse ${cache}: $_"
+        return $null
+    }
+    $candidates = @(
+        $outputs.portalFqdn,
+        $outputs.afdEndpointHostname,
+        $outputs.portalUrl,
+        $outputs.PORTAL_FQDN
+    ) | Where-Object { $_ -and -not [string]::IsNullOrWhiteSpace($_) }
+    if ($candidates.Count -eq 0) {
+        foreach ($prop in $outputs.PSObject.Properties) {
+            if ($prop.Value -is [string] -and $prop.Value -match '^[a-z0-9-]+\.[a-z0-9.-]+$') {
+                $candidates += $prop.Value
+            }
+        }
+    }
+    if ($candidates.Count -eq 0) {
+        Write-Warning "Could not find a portal hostname in $cache. Pass -RedirectUri explicitly."
+        return $null
+    }
+    $portalHost = $candidates[0]
+    if ($portalHost -notmatch '^https?://') { $portalHost = "https://$portalHost" }
+    return $portalHost.TrimEnd('/')
+}
+
+function Build-RequiredResourceAccessJson {
+    # Literal JSON - avoids PowerShell ConvertTo-Json mangling single-element arrays.
+    return @"
+[
+  {
+    "resourceAppId": "$MS_GRAPH_RESOURCE_APP_ID",
+    "resourceAccess": [
+      { "id": "$MS_GRAPH_USER_READ_SCOPE_ID", "type": "Scope" },
+      { "id": "$MS_GRAPH_GROUPMEMBER_READ_ALL_SCOPE_ID", "type": "Scope" }
+    ]
+  }
+]
+"@
+}
+
+function Build-OptionalClaimsJson {
+    param([bool]$IncludeGroups)
+    # Literal JSON - empty additionalProperties array MUST serialize as []. PowerShell's
+    # ConvertTo-Json converts @() to "" in PS 5.1 and to null in PS 7, neither of which
+    # Graph accepts.
+    if (-not $IncludeGroups) {
+        return '{"idToken":[],"accessToken":[],"saml2Token":[]}'
+    }
+    $groupClaim = '{"name":"groups","essential":false,"additionalProperties":[]}'
+    return "{`"idToken`":[$groupClaim],`"accessToken`":[$groupClaim],`"saml2Token`":[$groupClaim]}"
+}
+
+function Build-AppRolesJson {
+    # Two roles read by packages/portal/auth/authz/engine.js: 'admin' and 'user'.
+    # allowedMemberTypes=["User"] makes them assignable from "Users and groups".
+    $adminRoleId = [System.Guid]::NewGuid().ToString()
+    $userRoleId = [System.Guid]::NewGuid().ToString()
+    return @"
+[
+  {
+    "id": "$adminRoleId",
+    "allowedMemberTypes": ["User"],
+    "description": "Portal administrators. Grants full access including admin-only routes.",
+    "displayName": "Admin",
+    "isEnabled": true,
+    "value": "admin"
+  },
+  {
+    "id": "$userRoleId",
+    "allowedMemberTypes": ["User"],
+    "description": "Portal users. Grants standard signed-in access.",
+    "displayName": "User",
+    "isEnabled": true,
+    "value": "user"
+  }
+]
+"@
+}
+
+function Build-PlatformPatchBodyJson {
+    param([string]$RedirectUriArg)
+    # Literal JSON to guarantee redirectUris is always a JSON array, even when empty
+    # or single-element.
+    $urisJson = if ([string]::IsNullOrWhiteSpace($RedirectUriArg)) {
+        "[]"
+    } else {
+        $escaped = $RedirectUriArg.Replace('\', '\\').Replace('"', '\"')
+        "[`"$escaped`"]"
+    }
+    return @"
+{
+  "spa": { "redirectUris": $urisJson },
+  "web": {
+    "implicitGrantSettings": {
+      "enableAccessTokenIssuance": true,
+      "enableIdTokenIssuance": true
+    }
+  }
+}
+"@
+}
+
+function Invoke-GraphPatch {
+    param([string]$ObjectId, [string]$BodyJson, [string]$Description)
+    $tempFile = [System.IO.Path]::GetTempFileName()
+    try {
+        $BodyJson | Out-File -FilePath $tempFile -Encoding UTF8 -NoNewline
+        $out = az rest --method PATCH `
+            --uri "https://graph.microsoft.com/v1.0/applications/$ObjectId" `
+            --headers "Content-Type=application/json" `
+            --body "@$tempFile" 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            throw "Graph PATCH failed ($Description): $out"
+        }
+        Write-Host "  OK: $Description" -ForegroundColor Green
+    } finally {
+        Remove-Item $tempFile -Force -ErrorAction SilentlyContinue
+    }
+}
+
+# ---- Main ----
+
+Write-Host "Setup-PortalAuth - Entra app registration for PilotSwarm portal" -ForegroundColor Green
+Write-Host ""
+
+if (-not (Test-AzureCliReady)) { throw "Azure CLI not ready." }
+
+$tenantId = az account show --query "tenantId" -o tsv
+if ([string]::IsNullOrWhiteSpace($tenantId)) { throw "Could not read tenantId from 'az account show'." }
+Write-Host "Tenant ID: $tenantId"
+
+if ([string]::IsNullOrWhiteSpace($Owner)) {
+    $Owner = az ad signed-in-user show --query "id" -o tsv
+    if ([string]::IsNullOrWhiteSpace($Owner)) {
+        Write-Warning "Could not detect signed-in user; owner will not be set."
+        $Owner = $null
+    } else {
+        Write-Host "Owner (signed-in user): $Owner"
+    }
+}
+
+# Resolve redirect URI
+if ([string]::IsNullOrWhiteSpace($RedirectUri) -and -not [string]::IsNullOrWhiteSpace($EnvName)) {
+    $RedirectUri = Resolve-RedirectUriFromEnv -Env $EnvName
+    if ($RedirectUri) { Write-Host "Resolved redirect URI from env '$EnvName': $RedirectUri" }
+}
+if (-not [string]::IsNullOrWhiteSpace($RedirectUri)) {
+    if ($RedirectUri -notmatch '^https://') {
+        throw "RedirectUri must be https://. Got: $RedirectUri"
+    }
+}
+
+# Resolve display name
+if ([string]::IsNullOrWhiteSpace($DisplayName)) {
+    if (-not [string]::IsNullOrWhiteSpace($EnvName)) {
+        $DisplayName = "PilotSwarm Portal - $EnvName"
+    } else {
+        $DisplayName = "PilotSwarm Portal"
+    }
+}
+
+# Resolve output file
+if ([string]::IsNullOrWhiteSpace($OutputFile) -and -not [string]::IsNullOrWhiteSpace($EnvName)) {
+    $repo = Get-RepoRoot
+    $OutputFile = Join-Path $repo "deploy/envs/$EnvName/entra-app.json"
+}
+
+# Decide mode
+if (-not [string]::IsNullOrWhiteSpace($ExistingAppId)) {
+    Write-Host ""
+    Write-Host "Mode: ADD REDIRECT URI to existing app" -ForegroundColor Cyan
+    Write-Host "  Existing App ID: $ExistingAppId"
+    Write-Host "  New redirect URI: $RedirectUri"
+    if ([string]::IsNullOrWhiteSpace($RedirectUri)) {
+        throw "-RedirectUri (or -EnvName for auto-discovery) is required when -ExistingAppId is set."
+    }
+
+    $existing = az ad app show --id $ExistingAppId 2>$null | ConvertFrom-Json
+    if (-not $existing) { throw "Could not find app $ExistingAppId" }
+    $objectId = $existing.id
+    $currentUris = @()
+    if ($existing.spa -and $existing.spa.redirectUris) { $currentUris = @($existing.spa.redirectUris) }
+    if ($currentUris -contains $RedirectUri) {
+        Write-Host "Redirect URI already present - no change." -ForegroundColor Yellow
+    } else {
+        $newUris = @($currentUris + $RedirectUri | Select-Object -Unique)
+        $escapedUris = $newUris | ForEach-Object {
+            '"' + ($_.Replace('\', '\\').Replace('"', '\"')) + '"'
+        }
+        $urisArrJson = "[" + ($escapedUris -join ",") + "]"
+        $body = "{`"spa`":{`"redirectUris`":$urisArrJson}}"
+        Invoke-GraphPatch -ObjectId $objectId -BodyJson $body -Description "Append SPA redirect URI"
+    }
+
+    $clientId = $existing.appId
+} else {
+    Write-Host ""
+    Write-Host "Mode: CREATE NEW app registration" -ForegroundColor Cyan
+    Write-Host "  Display name        : $DisplayName"
+    Write-Host "  Tenant              : $tenantId (single-tenant)"
+    Write-Host "  Redirect URI        : $(if ($RedirectUri) { $RedirectUri } else { '<none - add later>' })"
+    Write-Host "  Service Tree ID     : $ServiceTreeId"
+    Write-Host "  Groups claim        : $(if ($SkipGroupsClaim) { 'NO' } else { 'YES (idToken+accessToken+saml2Token)' })"
+    Write-Host "  App roles           : $(if ($CreateAppRoles) { 'YES (admin + user)' } else { 'NO' })"
+    Write-Host "  Assignment required : $(if ($AssignmentRequired) { 'YES (only assigned users can sign in)' } else { 'NO (any tenant user can sign in)' })"
+    Write-Host ""
+
+    $tempFiles = @()
+    try {
+        $requiredResJson = Build-RequiredResourceAccessJson
+        $reqFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $reqFile
+        $requiredResJson | Out-File -FilePath $reqFile -Encoding UTF8 -NoNewline
+
+        $optClaimsJson = Build-OptionalClaimsJson -IncludeGroups (-not $SkipGroupsClaim)
+        $optFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $optFile
+        $optClaimsJson | Out-File -FilePath $optFile -Encoding UTF8 -NoNewline
+
+        $createArgs = @(
+            "ad", "app", "create",
+            "--display-name", $DisplayName,
+            "--sign-in-audience", "AzureADMyOrg",
+            "--service-management-reference", $ServiceTreeId,
+            "--required-resource-access", "@$reqFile",
+            "--optional-claims", "@$optFile"
+        )
+
+        if ($CreateAppRoles) {
+            $appRolesJson = Build-AppRolesJson
+            $rolesFile = [System.IO.Path]::GetTempFileName(); $tempFiles += $rolesFile
+            $appRolesJson | Out-File -FilePath $rolesFile -Encoding UTF8 -NoNewline
+            $createArgs += "--app-roles", "@$rolesFile"
+        }
+
+        Write-Host "Creating app registration..." -ForegroundColor Yellow
+        $createOut = az @createArgs
+        if ($LASTEXITCODE -ne 0) { throw "az ad app create failed: $createOut" }
+        $created = $createOut | ConvertFrom-Json
+        $clientId = $created.appId
+        $objectId = $created.id
+        Write-Host "  OK: Created app - appId=$clientId, objectId=$objectId" -ForegroundColor Green
+    } finally {
+        foreach ($f in $tempFiles) { if (Test-Path $f) { Remove-Item $f -Force -ErrorAction SilentlyContinue } }
+    }
+
+    # Configure SPA platform + implicit grant via Graph PATCH (az ad app create does not expose these)
+    $platformBody = Build-PlatformPatchBodyJson -RedirectUriArg $RedirectUri
+    Invoke-GraphPatch -ObjectId $objectId -BodyJson $platformBody -Description "Configure SPA platform + implicit grant (id+access tokens)"
+
+    # Set owner
+    if (-not [string]::IsNullOrWhiteSpace($Owner)) {
+        $null = az ad app owner add --id $clientId --owner-object-id $Owner 2>&1
+        if ($LASTEXITCODE -eq 0) { Write-Host "  OK: Set owner: $Owner" -ForegroundColor Green }
+        else { Write-Warning "Failed to set owner $Owner" }
+    }
+
+    # Create service principal
+    Write-Host "Creating service principal..." -ForegroundColor Yellow
+    $spOut = az ad sp create --id $clientId 2>&1
+    $spObjectId = $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Warning "Service principal creation failed: $spOut"
+    } else {
+        $sp = $spOut | ConvertFrom-Json
+        $spObjectId = $sp.id
+        Write-Host "  OK: Created service principal: $spObjectId" -ForegroundColor Green
+    }
+
+    # Set appRoleAssignmentRequired on the service principal
+    if ($AssignmentRequired -and $spObjectId) {
+        Write-Host "Setting appRoleAssignmentRequired=true on service principal..." -ForegroundColor Yellow
+        $null = az ad sp update --id $spObjectId --set appRoleAssignmentRequired=true 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  OK: appRoleAssignmentRequired=true (only assigned users will get a token)" -ForegroundColor Green
+        } else {
+            Write-Warning "Failed to set appRoleAssignmentRequired on $spObjectId"
+        }
+    }
+}
+
+# Write summary file
+$summary = [ordered]@{
+    tenantId       = $tenantId
+    clientId       = $clientId
+    objectId       = $objectId
+    displayName    = $DisplayName
+    redirectUri    = $RedirectUri
+    envName        = $EnvName
+    serviceTreeId  = $ServiceTreeId
+    appRolesCreated     = [bool]$CreateAppRoles
+    assignmentRequired  = [bool]$AssignmentRequired
+    createdAt      = (Get-Date).ToString("yyyy-MM-ddTHH:mm:ssZ")
+}
+if (-not [string]::IsNullOrWhiteSpace($OutputFile)) {
+    $parent = Split-Path -Parent $OutputFile
+    if ($parent -and -not (Test-Path $parent)) { New-Item -ItemType Directory -Force -Path $parent | Out-Null }
+    ($summary | ConvertTo-Json -Depth 4) | Out-File -FilePath $OutputFile -Encoding UTF8
+    Write-Host ""
+    Write-Host "Wrote summary to $OutputFile" -ForegroundColor Green
+}
+
+Write-Host ""
+Write-Host "=== PilotSwarm Portal App Registration ===" -ForegroundColor Green
+Write-Host "PORTAL_AUTH_ENTRA_TENANT_ID = $tenantId"
+Write-Host "PORTAL_AUTH_ENTRA_CLIENT_ID = $clientId"
+if ($RedirectUri) { Write-Host "Redirect URI                = $RedirectUri" }
+Write-Host "==========================================" -ForegroundColor Green
+Write-Host ""
+Write-Host "Next steps:" -ForegroundColor Cyan
+if ($EnvName) {
+    Write-Host "  1. Paste PORTAL_AUTH_ENTRA_CLIENT_ID into deploy/envs/$EnvName/.env (or your shared .env.remote)"
+} else {
+    Write-Host "  1. Paste PORTAL_AUTH_ENTRA_CLIENT_ID into your stamp's .env (or .env.remote)"
+}
+Write-Host "  2. Ensure PORTAL_AUTH_PROVIDER=entra and PORTAL_AUTH_ENTRA_TENANT_ID are set"
+if ($CreateAppRoles) {
+    Write-Host "  3. Assign users/groups to the 'admin' / 'user' app roles:"
+    Write-Host "        Entra portal > Enterprise applications > $DisplayName > Users and groups"
+    Write-Host "     (Required when -AssignmentRequired is also set, otherwise role-less principals fall through to PORTAL_AUTHZ_DEFAULT_ROLE)"
+    Write-Host "  4. Grant admin consent for GroupMember.Read.All:"
+} else {
+    Write-Host "  3. Grant admin consent for GroupMember.Read.All:"
+}
+Write-Host "        az ad app permission admin-consent --id $clientId"
+Write-Host "  5. Run the deploy flow as usual"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,19 @@ PORTAL_AUTHZ_USER_GROUPS=user1@contoso.com,user2@contoso.com
 For now, `PORTAL_AUTHZ_ADMIN_GROUPS` and `PORTAL_AUTHZ_USER_GROUPS` are interpreted
 as comma-delimited user email allowlists, not Entra group IDs.
 
+> **Provisioning the Entra app registration.** PilotSwarm ships
+> `deploy/scripts/auth/Setup-PortalAuth.ps1` to create (or append a
+> redirect URI to) the Entra application backing the portal. It
+> requires a `-ServiceTreeId` (operator-supplied) and supports two
+> optional switches that align with the role-driven authz engine:
+> `-CreateAppRoles` defines `admin` and `user` app roles on the
+> application object, and `-AssignmentRequired` flips the service
+> principal to require explicit user/group assignment before any token
+> is issued. See `deploy/scripts/auth/README.md` and the
+> `pilotswarm-portal-app-reg` skill for full usage. For npm-orchestrator
+> stamps, this is wired into the new-env flow by the
+> `pilotswarm-npm-deployer` agent.
+
 Portal branding and sign-in copy come from `plugin.json.portal`, with
 `plugin.json.tui` used as a fallback when the portal plugin metadata does not
 provide an override. Preferred portal metadata shape is nested under

--- a/docs/deploying-to-aks.md
+++ b/docs/deploying-to-aks.md
@@ -431,6 +431,16 @@ Register the portal ingress URL as the SPA redirect URI in Entra. The portal
 core does not require Entra specifically, so alternate providers can use the
 same deployment slot without changing the portal shell contract.
 
+> **Automating the app registration.** Rather than clicking through the
+> Azure Portal, use `deploy/scripts/auth/Setup-PortalAuth.ps1` to create
+> the Entra application, register the SPA redirect URI, and (optionally)
+> define the `admin`/`user` app roles consumed by the portal authz
+> engine. The script requires `-ServiceTreeId` (operator-supplied) and
+> exposes `-CreateAppRoles` and `-AssignmentRequired` switches for
+> role-driven and lockdown postures. Full operator docs:
+> `deploy/scripts/auth/README.md`. Agent-driven invocation:
+> `pilotswarm-portal-app-reg` skill.
+
 Use the canonical `PORTAL_AUTH_*` / `PORTAL_AUTHZ_*` keys only. The portal no
 longer reads legacy `ENTRA_*` aliases.
 


### PR DESCRIPTION
## Summary

Ports the deployer toolchain (1 agent + 2 skills + 3 PowerShell scripts) from the Waldemort downstream consumer back into PilotSwarm — Waldemort originally vendored the npm Bicep/GitOps orchestrator from this repo, so the operator material is returning home with PilotSwarm-correct topology and the Lord Waldemort persona dropped.

**Primary motivation:** close the Entra app-registration automation gap that blocks smoke-testing the role-driven authz feature shipped in #35. Operators (and the new agent) can now run a single `pwsh` command to provision the portal's Entra app registration with the right shape for the authz engine.

## What's new

**`deploy/scripts/auth/`** (3 files)
- `Create3PApplication.ps1` — generic Azure AD app primitive.
- `Setup-PortalAuth.ps1` — opinionated portal wrapper.
  - `-ServiceTreeId` is a **required** parameter (no default). Operator supplies their own Service Tree entry.
  - `-CreateAppRoles` — defines `admin` and `user` app roles consumed by the PR #35 authz engine.
  - `-AssignmentRequired` — sets `appRoleAssignmentRequired` on the SP so only assigned users can get a token (closes the gap where unassigned tenant users still fell through to `PORTAL_AUTHZ_DEFAULT_ROLE`).
- `README.md` — operator docs with a 3-posture matrix.

**`.github/skills/pilotswarm-portal-app-reg/SKILL.md`** — agent skill for invoking the script. Includes the 3-posture matrix (Open / Roles, no lockdown / Roles + lockdown).

**`.github/skills/pilotswarm-new-env-deploy/SKILL.md`** — operator skill for `deploy/scripts/deploy.mjs` + `new-env.mjs`. Covers fresh-scaffold vs rollout-to-existing paths, EDGE_MODE × TLS_SOURCE matrix, per-service redeploys with `--steps`, `--force-module` semantics, AFD propagation delay, and the boundary against the legacy bash path.

**`.github/agents/pilotswarm-npm-deployer.agent.md`** — new agent for the npm orchestrator path. Coexists with the existing `pilotswarm-aks-deployer` (legacy bash). Includes DO NOT WIPE handshake, readline-echo guidance, and the Entra app-reg pre-step.

## What's modified

- `.github/agents/pilotswarm-aks-deployer.agent.md` — top-of-file path-boundary pointer to the new npm deployer agent.
- `docs/configuration.md`, `docs/deploying-to-aks.md` — cross-link `Setup-PortalAuth.ps1` from the existing portal-auth sections.

## Notable refactors from the Waldemort sources

- `wdm<name>` resource prefix → `ps<name>` (PilotSwarm scaffolder default).
- `deploy/envs/<stamp>/.env` paths → `deploy/envs/local/<stamp>/.env` (PilotSwarm subdir layout).
- Hardcoded Waldemort Service Tree ID → required `-ServiceTreeId` parameter.
- Hardcoded Microsoft tenant id → "whatever `az account show` returns".
- Lord Waldemort persona dropped from the agent; neutral voice throughout.
- Live-cluster routing dropped from the new agent; handed off to the existing `pilotswarm-aks-deployer` for that path.
- `EXTERNAL_ACR_*` defaults intentionally **kept** pinned to `waldemortcr` — that's a real dependency for the `waldemort-tools` image, documented as overridable in `deploy/scripts/README.md`.

## Verification

- `pwsh -File Setup-PortalAuth.ps1` (no args) → correctly errors on missing mandatory `-ServiceTreeId` ✓
- `pwsh -File Setup-PortalAuth.ps1 -ServiceTreeId <dummy> -EnvName smoketest` → param surface parses, reaches mode summary, fails at `az ad app create` because the bogus Service Tree ID is rejected by tenant policy — no app leaked ✓
- `grep -ri 'waldemort' deploy/scripts/auth/ .github/skills/pilotswarm-portal-app-reg/ .github/skills/pilotswarm-new-env-deploy/ .github/agents/pilotswarm-npm-deployer.agent.md` → zero hits ✓
- `grep -r '1e563e79-6593-45d0-a8ca-232780e0eeae'` → zero hits in new files ✓
- No JS code touched — existing tests unaffected.

## Not in scope

- Smoke-testing against a real Entra tenant (separate session — operator action).
- Provisioning a real PilotSwarm Service Tree entry (operator concern).
- Rebranding the `waldemortcr` external ACR pin (intentional dependency).
