### PR TITLE
v0.1.35: hotfix - declare @opentelemetry/api as SDK direct dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 0.1.35 — 2026-05-29
+
+### SDK — Hotfix: declare `@opentelemetry/api` as a dependency
+
+- `packages/sdk/src/session-proxy.ts` hard-imports
+  `@opentelemetry/api` (added in v0.1.33 alongside the SigNoz
+  observability work) but the package was not declared in
+  `packages/sdk/package.json` dependencies. Any consumer that
+  installed `pilotswarm-sdk@0.1.33` or `0.1.34` standalone
+  (i.e. not inside this monorepo) would crash on first import
+  with `ERR_MODULE_NOT_FOUND: Cannot find package
+  '@opentelemetry/api'`. Adds `^1.9.0` as a direct dep so
+  fresh installs are self-contained.
+- No behavior change. No API change. SDK consumers that already
+  worked around this by adding `@opentelemetry/api` to their own
+  `package.json` can keep that pin or drop it — either resolves
+  to the same version.
+
 ## 0.1.34 — 2026-05-29
 
 ### Portal — Deny-by-default authz

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Experimental** — This project is under active development and not yet ready for production use. APIs may change without notice.
 
-> **Latest release: v0.1.34** — Portal deny-by-default authz: signed-in principals without a `roles` claim or email allowlist match are now denied at the portal layer; `Setup-PortalAuth.ps1 -CreateAppRoles` plus Entra role assignments is the recommended lockdown, and `appRoleAssignmentRequired` defaults to `false` to avoid AADSTS90094 admin-consent prompts in restricted tenants. See [`docs/portal-entra-app-roles.md`](docs/portal-entra-app-roles.md) for migration guidance.
+> **Latest release: v0.1.35** — Hotfix: `pilotswarm-sdk` now declares `@opentelemetry/api` as a direct dependency (it was hard-imported by `session-proxy.ts` in v0.1.33+ but not listed in `package.json`, so standalone installs crashed at import time). No behavior change. v0.1.34 release notes remain accurate for portal authz behavior.
 
 A durable execution runtime for [GitHub Copilot SDK](https://github.com/github/copilot-sdk) agents. Crash recovery, durable timers, session dehydration, and multi-node scaling — powered by [duroxide](https://github.com/microsoft/duroxide). Just add a connection string.
 

--- a/docs/getting-started-docker-appliance.md
+++ b/docs/getting-started-docker-appliance.md
@@ -27,7 +27,7 @@ Silicon.
 If you want the exact released build instead of the moving `latest` tag, pull the versioned image:
 
 ```bash
-docker pull affandar/pilotswarm-starter:0.1.34
+docker pull affandar/pilotswarm-starter:0.1.35
 ```
 
 ---

--- a/docs/user-guide/portal.md
+++ b/docs/user-guide/portal.md
@@ -13,7 +13,7 @@ Either:
 - **Docker quickstart** (easiest): `docker run -d -p 127.0.0.1:3001:3001 -p 127.0.0.1:2222:2222 -e GITHUB_TOKEN -v pilotswarm-data:/data --name pilotswarm-starter affandar/pilotswarm-starter:latest`. Then open `http://localhost:3001`.
 - **From source**: `npm install && npm run build`, set up `.env` (see [getting-started.md](../getting-started.md)), then `npm run portal:start` (or `./scripts/portal-start.sh`). Open `http://localhost:3001`.
 
-For a pinned Docker quickstart, replace `latest` with `0.1.34`.
+For a pinned Docker quickstart, replace `latest` with `0.1.35`.
 
 For deployments with Entra ID auth enabled (production), you'll see a
 sign-in flow first. For local development, sign-in is bypassed.

--- a/docs/user-guide/tui.md
+++ b/docs/user-guide/tui.md
@@ -17,7 +17,7 @@ Either:
 - **Docker quickstart** (easiest): `docker run -d -p 127.0.0.1:3001:3001 -p 127.0.0.1:2222:2222 -e GITHUB_TOKEN -v pilotswarm-data:/data --name pilotswarm-starter affandar/pilotswarm-starter:latest`, then `ssh -p 2222 pilotswarm@localhost` (password: `pilotswarm`).
 - **From source**: clone the repo, run `npm install && npm run build`, set up `.env` (see [getting-started.md](../getting-started.md)), then `./run.sh local --db`.
 
-For a pinned Docker quickstart, replace `latest` with `0.1.34`.
+For a pinned Docker quickstart, replace `latest` with `0.1.35`.
 
 In either case you'll land on the **Sessions** pane focused on the left.
 That's the entry point for everything below.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9111,7 +9111,7 @@
     },
     "packages/cli": {
       "name": "pilotswarm-cli",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bundleDependencies": [
         "pilotswarm-ui-core",
         "pilotswarm-ui-react"
@@ -9119,7 +9119,7 @@
       "license": "MIT",
       "dependencies": {
         "ink": "^6.8.0",
-        "pilotswarm-sdk": "^0.1.34",
+        "pilotswarm-sdk": "^0.1.35",
         "pilotswarm-ui-core": "0.1.0",
         "pilotswarm-ui-react": "0.1.0",
         "react": "^19.2.4"
@@ -9150,7 +9150,7 @@
     },
     "packages/portal": {
       "name": "pilotswarm-web",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "bundleDependencies": [
         "pilotswarm-ui-core",
         "pilotswarm-ui-react"
@@ -9160,7 +9160,7 @@
         "@azure/msal-browser": "^4.26.1",
         "express": "^5.1.0",
         "jose": "^6.2.2",
-        "pilotswarm-cli": "^0.1.34",
+        "pilotswarm-cli": "^0.1.35",
         "pilotswarm-ui-core": "0.1.0",
         "pilotswarm-ui-react": "0.1.0",
         "react": "^19.2.4",
@@ -9255,13 +9255,14 @@
     },
     "packages/sdk": {
       "name": "pilotswarm-sdk",
-      "version": "0.1.34",
+      "version": "0.1.35",
       "license": "MIT",
       "dependencies": {
         "@azure/identity": "^4.13.1",
         "@azure/storage-blob": "^12.31.0",
         "@github/copilot": "^1.0.50",
         "@github/copilot-sdk": "^1.0.0-beta.4",
+        "@opentelemetry/api": "^1.9.0",
         "duroxide": "^0.1.27",
         "file-type": "^20.5.0",
         "pg": "^8.18.0"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilotswarm-cli",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "Terminal UI for PilotSwarm.",
   "type": "module",
   "bin": {
@@ -38,7 +38,7 @@
   },
   "dependencies": {
     "ink": "^6.8.0",
-    "pilotswarm-sdk": "^0.1.34",
+    "pilotswarm-sdk": "^0.1.35",
     "pilotswarm-ui-core": "0.1.0",
     "pilotswarm-ui-react": "0.1.0",
     "react": "^19.2.4"

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilotswarm-web",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": false,
   "description": "Browser-native web portal for PilotSwarm with shared controller/state/theme reuse.",
   "type": "module",
@@ -37,7 +37,7 @@
     "@azure/msal-browser": "^4.26.1",
     "express": "^5.1.0",
     "jose": "^6.2.2",
-    "pilotswarm-cli": "^0.1.34",
+    "pilotswarm-cli": "^0.1.35",
     "pilotswarm-ui-core": "0.1.0",
     "pilotswarm-ui-react": "0.1.0",
     "react": "^19.2.4",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pilotswarm-sdk",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "description": "A durable execution runtime for GitHub Copilot SDK agents. Crash recovery, durable timers, session dehydration, and multi-node scaling — powered by duroxide.",
   "type": "module",
   "main": "./dist/index.js",
@@ -66,6 +66,7 @@
     "@azure/storage-blob": "^12.31.0",
     "@github/copilot": "^1.0.50",
     "@github/copilot-sdk": "^1.0.0-beta.4",
+    "@opentelemetry/api": "^1.9.0",
     "duroxide": "^0.1.27",
     "file-type": "^20.5.0",
     "pg": "^8.18.0"


### PR DESCRIPTION
## Summary

packages/sdk/src/session-proxy.ts hard-imports @opentelemetry/api (added with the SigNoz work in v0.1.33), but the package was never declared in packages/sdk/package.json dependencies. Any consumer that installs pilotswarm-sdk@0.1.33 or 