### PR TITLE
test(cms): fix CMS metadata event-read race in validateSessionAfterTurn

### DIFF
--- a/packages/sdk/test/helpers/cms-helpers.js
+++ b/packages/sdk/test/helpers/cms-helpers.js
@@ -158,7 +158,16 @@ export async function validateSessionAfterTurn(env, sessionId, opts = {}) {
         }
 
         // ── 3. CMS events: existence + ordering ────────────────
-        const events = await catalog.getSessionEvents(sessionId);
+        // The state poll above can return at state="running" the instant the
+        // turn starts, before the first events (session.turn_started, …) have
+        // committed. Poll briefly for the first event rather than sampling once,
+        // mirroring the state and orchestration-status polls in this function.
+        let events = await catalog.getSessionEvents(sessionId);
+        const eventsDeadline = Date.now() + 20_000;
+        while (events.length === 0 && Date.now() < eventsDeadline) {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            events = await catalog.getSessionEvents(sessionId);
+        }
         if (events.length === 0) {
             throw new Error(`[CMS] No events persisted for session ${sessionId.slice(0, 8)}`);
         }


### PR DESCRIPTION
This is a **test-harness only** change (no product code).

**Problem.** `validateSessionAfterTurn` (packages/sdk/test/helpers/cms-helpers.js) polls for session **state** and orchestration **status** with a bounded deadline, but reads `session_events` exactly **once**. When `expectedCmsStates` includes `"running"` — e.g. the `system-agents` *Child Agent CMS Metadata* test — the state poll returns immediately at 0 persisted events, so the event-existence assertion fails with *"No events persisted"* even though the parent session persists `session.turn_started` within a few seconds. This is a read/write race in the test helper, not a product defect.

**Fix.** Poll for the first event using the **same bounded 20s deadline** already applied to the state/status checks, so the helper waits for CMS event persistence instead of racing it (+10/-1).

**Validation.** Full `--all-providers` run on main (0.5.20): `system-agents > Child Agent CMS Metadata` now **passes** (9766ms); verified 3/3 stable in isolation. No other tests are affected by this change.