### PR TITLE
fix(horizon-store): always send embeddings input as an array (Cohere 422 fix)

### DIFF
--- a/packages/horizon-store/src/embedding-client.ts
+++ b/packages/horizon-store/src/embedding-client.ts
@@ -43,7 +43,7 @@ export class EmbeddingClient {
             headers[headerName] = this.cfg.bearer ? `Bearer ${this.cfg.apiKey}` : this.cfg.apiKey;
         }
 
-        const body = JSON.stringify({ [inputField]: texts.length === 1 ? texts[0] : texts, model: this.cfg.model });
+        const body = JSON.stringify({ [inputField]: texts, model: this.cfg.model });
 
         const controller = new AbortController();
         const timer = setTimeout(() => controller.abort(), this.cfg.timeoutMs ?? 30_000);


### PR DESCRIPTION
Fixes a provider-compatibility bug in the Node embeddings client.

**Problem.** `EmbeddingClient.embedBatch` (packages/horizon-store/src/embedding-client.ts) sent the `input` field as a **bare string** whenever the batch had exactly one text:
```js
const body = JSON.stringify({ [inputField]: texts.length === 1 ? texts[0] : texts, model: this.cfg.model });
```
OpenAI / Azure-OpenAI accept `input` as a string **or** an array, but a **Cohere-format** Azure AI Model Inference embeddings endpoint (`/models/embeddings`) rejects a bare string with **HTTP 422 "Input should be a valid list"**. This breaks every single-input embed — all query-time embeds and any single-fact batch — against Cohere-format endpoints.

**Fix.** Always send `input` as an array:
```js
const body = JSON.stringify({ [inputField]: texts, model: this.cfg.model });
```
This is a strict superset: OpenAI/Azure-OpenAI treat a one-element array identically to a bare string, so the existing OpenAI path is unaffected; Cohere-format endpoints now work. The in-database embedder mirror (`migrations/0005-0011`) already sends an array via `jsonb_agg`, so only the Node client needed the change (+1/-1).

**Validation.** Against a live Cohere-format endpoint (`Cohere-embed-v3-english`, dim 1024): before the fix, `embedder-outcomes.test.mjs` query/hybrid tests threw the 422; after the fix the **422 is gone** and the query/hybrid semantic tests pass. Verified the OpenAI path is unaffected (array input is accepted identically).