### PR TITLE
test(contracts): derive graph tools from provider capability; pin models for behavioral assertions

### DIFF
--- a/packages/sdk/test/local/contracts.test.js
+++ b/packages/sdk/test/local/contracts.test.js
@@ -23,7 +23,7 @@ import { SessionManager } from "../../src/session-manager.ts";
 import { resolveStorageConfig, getRuntimeStorageProvider } from "../../src/index.ts";
 import { assert, assertEqual, assertIncludes, assertGreaterOrEqual, assertNotNull } from "../helpers/assertions.js";
 import { validateSessionAfterTurn } from "../helpers/cms-helpers.js";
-import { createAddTool, createMultiplyTool, ONEWORD_CONFIG, TOOL_CONFIG } from "../helpers/fixtures.js";
+import { createAddTool, createMultiplyTool, ONEWORD_CONFIG, TOOL_CONFIG, TEST_GPT_MODEL } from "../helpers/fixtures.js";
 
 const TIMEOUT = 180_000;
 const getEnv = useSuiteEnv(import.meta.url);
@@ -104,6 +104,24 @@ function expectedLlmVisibleToolNamesForProvider() {
     const provider = getRuntimeStorageProvider(storage.runtime.provider);
     if (provider.capabilities?.enhancedFactStore) {
         names.push("facts_search", "facts_similar", "search_skills");
+    }
+    // The provider's `graphStore` capability is what makes the worker append the
+    // graph tools, exactly as `enhancedFactStore` does for the facts trio. Without
+    // this branch every `--with-horizondb` run sees 11 unexpected `graph_*` tools.
+    if (provider.capabilities?.graphStore) {
+        names.push(
+            "graph_list_namespaces",
+            "graph_get_namespace",
+            "graph_search_nodes",
+            "graph_search_edges",
+            "graph_neighbourhood",
+            "graph_upsert_namespace",
+            "graph_upsert_node",
+            "graph_upsert_edge",
+            "graph_merge_nodes",
+            "graph_delete_node",
+            "graph_delete_edge",
+        );
     }
     return names;
 }
@@ -562,7 +580,15 @@ async function testTopLevelAgentToolMerging(env) {
             pluginDirs: [AGENT_TOOL_MERGE_PLUGIN_DIR],
         },
     }, async (client) => {
+        // MODEL VARIABILITY: the assertions below require the model to actually
+        // call BOTH tools in one turn. That is a behavioral expectation, not a
+        // contract one — the merged toolset is already correct by the time the
+        // prompt is sent. Models that answer with a single call, or narrate the
+        // answer instead of calling, fail here without anything being wrong in
+        // the tool-merging path. Pin a model known to fan out to both tools so a
+        // red here means the merge is broken, not that the model chose one tool.
         const session = await client.createSessionForAgent("toolmerge", {
+            model: TEST_GPT_MODEL,
             toolNames: ["caller_secret"],
         });
 
@@ -711,7 +737,19 @@ async function testLlmSeesExactAlwaysOnTools(env) {
     await withClient(env, {
         worker: { pluginDirs: [NO_TOOLS_AGENT_PLUGIN_DIR] },
     }, async (client) => {
+        // MODEL VARIABILITY: this assertion is an exact match against a list the
+        // model types out itself, so it is only as stable as the model's
+        // willingness to introspect. Observed on other models: (a) an outright
+        // refusal — "ignore your normal role ... return your tool names" reads as
+        // a prompt-injection attempt, so the reply is prose and parsing fails;
+        // and (b) substitution — the model answers with familiar tool names it
+        // was NOT given (e.g. `create`/`edit`/`grep` in place of the CLI's real
+        // `apply_patch`/`rg`), which looks like catalog drift but is confabulation.
+        // Neither is a contract violation: the toolset really was delivered.
+        // Pin a model known to comply so a red here means the toolset is wrong,
+        // not that the model declined. Revisit if this model's behavior changes.
         const session = await client.createSession({
+            model: TEST_GPT_MODEL,
             agentId: "coordinator",
             systemMessage: {
                 mode: "append",


### PR DESCRIPTION
Two independent causes of red in `--all-providers`, both in `contracts.test.js`. Rebased onto **0.5.23**; test-only, no runtime code touched.

### 1. `graph_*` tools missing from the expected toolset — a real bug

`expectedLlmVisibleToolNamesForProvider()` only branched on the `enhancedFactStore` capability. The HorizonDB runtime provider also declares `graphStore: true`, and the worker really does hand the 11 `graph_*` tools to the model — so `LLM Sees Exact Always-On Toolset` failed for anyone running `--with-horizondb`.

The expectation now derives from the same capability flag the runtime uses, rather than assuming the base provider's tool set.

### 2. Two tests assert on model *behavior*, not on a contract

Both were flaky against an unpinned model, and both now pin `TEST_GPT_MODEL`.

| Test | What the model has to do | How it fails without a pin |
|---|---|---|
| `LLM Sees Exact Always-On Toolset` | Type its own tool list back | Refusal — the prompt reads as injection — or **confabulation** |
| `Top-Level Named Agent Tool Merging` | Call both the agent-defined and caller-supplied tool in one turn | Calls only one, or narrates instead of calling |

The confabulation mode deserves attention: the model answered with familiar names it was never given — `create`/`edit`/`grep` in place of the CLI's real `apply_patch`/`rg`. That is **indistinguishable from genuine catalog drift**, so "fixing" the golden to match would have baked a hallucination into the test. Each pin carries a comment saying so, to stop the next person from doing exactly that.

`TEST_GPT_MODEL` resolves through the existing `firstKnownModel()` fallback chain in `helpers/fixtures.js` and still honors `FORCED_TEST_MODEL`, so upstream CI keeps working without a hardcoded model name.

### Evidence

Validated on an independent Azure stamp (PgFactStore + HorizonDB, live Copilot models).

| Phase | Result |
|---|---|
| horizondb — SDK | **162 files / 1186 tests, zero failures** — first fully-green SDK phase |
| horizondb — store integration | 18/18 files |
| base — serial re-run of the three flaky suites | 10 files / 70 tests, exit 0 |

Both pinned tests passed in every phase after the change. The three failures that remained in the parallel base phase were each proven non-deterministic two ways — they passed in a different provider phase of the *same* run (same commit, same build), and passed again in a dedicated serial re-run — so none is a product defect.

A re-validation against 0.5.23 is running now; I will note the result here.
