### PR TITLE
Add "Hide page chrome" option to canvas share links

### DIFF
--- a/docs/user-guide/portal.md
+++ b/docs/user-guide/portal.md
@@ -186,6 +186,19 @@ changes anywhere, your browser reflects it within a poll cycle.
   If the linked session is outside your current filters, it is shown
   anyway with a "Showing linked session outside your current filters"
   notice until you navigate or change filters.
+- A canvas has its own **Share canvas** dialog with two audiences. Its
+  **Session access** tab produces a normal deep link — the recipient signs
+  in and the usual visibility rules decide whether they get in — and offers
+  a **Hide page chrome** checkbox (off by default). Checked, the link gains
+  `show_chrome=false` and lands on the canvas alone: no portal header, no
+  workspace around it, just a thin strip naming the deployment and a
+  deliberately faint **Show chrome** button that brings the header back
+  without reloading. This is presentation only. It changes nothing about
+  access — a parameter in a URL is not a permission, and the recipient can
+  simply delete it — so who may edit inside the app is still decided by
+  "Who can edit inside this app" in the same dialog. The **Anyone with
+  link** tab is the different thing: a token that needs no sign-in at all
+  and is always read-only.
 
 ---
 

--- a/packages/app/ui/react/src/web-app.js
+++ b/packages/app/ui/react/src/web-app.js
@@ -6877,8 +6877,19 @@ function CanvasShareDialog({ controller, sessionId, slot, onClose }) {
     // the policy, so the control is disabled for everyone else rather than
     // letting them pick a value and then showing a refusal.
     const [kvMe, setKvMe] = React.useState(null);
+    // Off by default: every link this dialog has ever produced opened the full
+    // workspace, and a share option that silently changed that for existing
+    // habits would be a surprise. Checked, the link carries `show_chrome=false`
+    // and lands on the canvas alone.
+    //
+    // Presentation only. It hides the portal header; it does NOT make the
+    // canvas read-only, because a query parameter is not a permission — the
+    // recipient can simply delete it. What a viewer may change inside the app
+    // stays governed by the KV policy below, and the strip is worded so it
+    // never implies otherwise.
+    const [hideChrome, setHideChrome] = React.useState(false);
     const transport = controller.transport;
-    const sessionLink = `${window.location.origin}/?session=${encodeURIComponent(sessionId)}&view=canvas&slot=${slot}&max=1`;
+    const sessionLink = `${window.location.origin}/?session=${encodeURIComponent(sessionId)}&view=canvas&slot=${slot}&max=1${hideChrome ? "&show_chrome=false" : ""}`;
     // The token variants all resolve the same hashed row: one token, N doors,
     // single-switch revocation whichever door the bearer uses.
     const linkRows = (url, keyPrefix) => React.createElement(MultiOriginLinkRows, {
@@ -6965,6 +6976,13 @@ function CanvasShareDialog({ controller, sessionId, slot, onClose }) {
                 },
                     React.createElement("div", { className: "ps-canvas-share-sub" }, "Opens the portal signed in, canvas full screen. Session visibility rules apply."),
                     linkRows(sessionLink, "session"),
+                    React.createElement("label", { className: "ps-canvas-share-check" },
+                        React.createElement("input", {
+                            type: "checkbox",
+                            checked: hideChrome,
+                            onChange: (event) => setHideChrome(event.target.checked),
+                        }),
+                        "Hide page chrome"),
                     // Who may WRITE the app's shared state. Stated in words:
                     // "readers" reaches everyone the session is read-shared
                     // with, which a dialog that only says "link" hides.

--- a/packages/app/ui/react/src/web-app.js
+++ b/packages/app/ui/react/src/web-app.js
@@ -1,7 +1,8 @@
 import React from "react";
-// createPortal is only invoked when an IconButton tooltip renders (portal only,
-// never in the TUI); the import itself is side-effect-free and react-dom is a
-// dependency wherever this file loads, so it is safe in the shared module.
+// createPortal is only invoked by browser-only surfaces (tooltips, toolbar
+// slots, and viewport-level dialogs); the import itself is side-effect-free
+// and react-dom is a dependency wherever this file loads, so it is safe in the
+// shared module.
 import { createPortal } from "react-dom";
 import { appendAnimatedDotsToRuns, useAnimatedDots, useSpinnerFrame } from "./chat-status.js";
 import {
@@ -6944,7 +6945,7 @@ function CanvasShareDialog({ controller, sessionId, slot, onClose }) {
             .finally(() => setBusy(false));
     };
 
-    return React.createElement("div", { className: "ps-canvas-share-overlay", onClick: onClose },
+    const overlay = React.createElement("div", { className: "ps-canvas-share-overlay", onClick: onClose },
         React.createElement("div", { className: "ps-canvas-share-dialog", onClick: (e) => e.stopPropagation(), role: "dialog", "aria-label": "Share canvas" },
             React.createElement("div", { className: "ps-canvas-share-title" },
                 "Share this canvas",
@@ -7034,6 +7035,16 @@ function CanvasShareDialog({ controller, sessionId, slot, onClose }) {
                             ? React.createElement("button", { type: "button", className: "ps-mini-button", disabled: busy, onClick: remove }, "Remove link")
                             : null))),
             error ? React.createElement("div", { className: "ps-canvas-share-error" }, error) : null));
+
+    // CanvasPane lives inside `.ps-canvas-layer`, which is a z-indexed
+    // stacking context below the pane resizers. A fixed overlay left inside
+    // that tree cannot out-rank a sibling resizer regardless of its own
+    // z-index, so the divider used to paint straight through this dialog.
+    // Put viewport chrome at the document root; React keeps context and event
+    // bubbling intact across the portal.
+    return typeof document !== "undefined" && document.body
+        ? createPortal(overlay, document.body)
+        : overlay;
 }
 
 /**

--- a/packages/app/web/src/App.jsx
+++ b/packages/app/web/src/App.jsx
@@ -7,6 +7,12 @@ import { selectSessionFilterExceptionNotice, selectStatusBar } from "pilotswarm/
 import { BrowserPortalTransport } from "./browser-transport.js";
 import { usePortalAuth } from "./auth-client.js";
 import { PILOTSWARM_PORTAL_VERSION_LABEL } from "./version.js";
+import {
+    DEEP_LINK_SESSION_STORAGE_KEY,
+    parseStashedDeepLinkTarget,
+    readDeepLinkTargetFromUrl,
+    writeShowChromeParam,
+} from "./lib/deep-link.js";
 
 const DEFAULT_PORTAL_LOGO_SVG = `
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
@@ -27,38 +33,6 @@ const DEFAULT_PORTAL_LOGO_SVG = `
 
 const DEFAULT_PORTAL_FAVICON_URL = `data:image/svg+xml,${encodeURIComponent(DEFAULT_PORTAL_LOGO_SVG)}`;
 const GENERIC_SIGN_IN_MESSAGE = "Use your organization's identity provider to open the browser-native PilotSwarm workspace.";
-// Deep links stash ?session= in sessionStorage before sign-in because the
-// redirect-based sign-in path (mobile Entra loginRedirect) returns to the bare
-// redirectUri and drops the query string; popup/dev sign-ins never navigate,
-// so the URL param survives those on its own.
-const DEEP_LINK_SESSION_STORAGE_KEY = "pilotswarm.portal.deepLinkSession";
-
-/**
- * A deep-link target: `?session=<id>[&artifact=<filename>][&view=full|canvas]`.
- *
- * The artifact form is what the agent's show_artifact tool hands back and what
- * the Files "copy link" button produces, so a link pasted into chat, mailed to
- * a colleague, or opened in a new tab all land on the same preview.
- * `view=canvas` opens the session with its canvas up — the shareable "look at
- * the dashboard" link.
- */
-function readDeepLinkTargetFromUrl() {
-    if (typeof window === "undefined" || !window.location) return null;
-    const params = new URLSearchParams(window.location.search);
-    const sessionId = (params.get("session") || "").trim();
-    if (!sessionId) return null;
-    const artifact = (params.get("artifact") || "").trim();
-    const view = (params.get("view") || "").trim().toLowerCase();
-    return {
-        sessionId,
-        artifact: artifact || null,
-        fullscreen: view === "full",
-        canvas: view === "canvas",
-        // ?max=1 with view=canvas: arrive with the canvas COVERING the
-        // workspace — the share-link landing experience.
-        max: params.get("max") === "1",
-    };
-}
 
 function stashDeepLinkTarget() {
     const target = readDeepLinkTargetFromUrl();
@@ -67,27 +41,6 @@ function stashDeepLinkTarget() {
         window.sessionStorage.setItem(DEEP_LINK_SESSION_STORAGE_KEY, JSON.stringify(target));
     } catch {
         // Session storage unavailable; the URL params still cover non-redirect sign-ins.
-    }
-}
-
-function parseStashedDeepLinkTarget(raw) {
-    if (!raw) return null;
-    // Older builds stashed a bare session id string. A stash written before an
-    // upgrade can still be sitting in this tab when the new bundle loads.
-    if (!raw.startsWith("{")) return { sessionId: raw, artifact: null, fullscreen: false };
-    try {
-        const parsed = JSON.parse(raw);
-        const sessionId = String(parsed?.sessionId || "").trim();
-        if (!sessionId) return null;
-        return {
-            sessionId,
-            artifact: parsed?.artifact ? String(parsed.artifact) : null,
-            canvas: Boolean(parsed?.canvas),
-            fullscreen: Boolean(parsed?.fullscreen),
-            max: Boolean(parsed?.max),
-        };
-    } catch {
-        return null;
     }
 }
 
@@ -620,6 +573,31 @@ function PortalMobileStatus({ statusText, onDismiss }) {
         }, "✕"));
 }
 
+/**
+ * The bare strip that stands in for the portal header when a link asked for
+ * `show_chrome=false`.
+ *
+ * It names the deployment through the SAME `getWorkspaceTitle` the real header
+ * kicker uses, so the two can never disagree: a stock deployment reads
+ * "PilotSwarm", and one whose plugin sets `portal.title` reads that instead.
+ *
+ * The restore control is deliberately recessed — near-invisible until hovered
+ * or focused — because the whole point of this mode is that nothing competes
+ * with the canvas. It stays a real <button> with a visible focus ring so
+ * keyboard users can still reach it.
+ */
+function PortalChromelessStrip({ branding, onShowChrome }) {
+    return React.createElement("div", { className: "portal-chromeless-strip" },
+        React.createElement("span", { className: "portal-chromeless-strip-label" },
+            `${getWorkspaceTitle(branding)} · Live canvas`),
+        React.createElement("button", {
+            type: "button",
+            className: "portal-chromeless-strip-restore",
+            onClick: onShowChrome,
+            title: "Show the header and workspace chrome",
+        }, "Show chrome"));
+}
+
 function PortalWorkspace({ auth, portal, shellStyle }) {
     const transport = React.useMemo(() => new BrowserPortalTransport({
         getAccessToken: auth.getAccessToken,
@@ -647,6 +625,10 @@ function PortalWorkspace({ auth, portal, shellStyle }) {
     const mobileStatusText = statusText && statusText !== dismissedStatus ? statusText : "";
     const deepLinkTarget = React.useMemo(() => consumeDeepLinkTarget(), []);
     const initialSessionId = deepLinkTarget?.sessionId || null;
+    // State rather than a bare read of the target, so "Show chrome" can put the
+    // header back without a reload (which would re-consume nothing — the deep
+    // link is consumed once per page load — and lose the open canvas).
+    const [chromeHidden, setChromeHidden] = React.useState(() => Boolean(deepLinkTarget?.hideChrome));
 
     React.useEffect(() => {
         let active = true;
@@ -665,7 +647,14 @@ function PortalWorkspace({ auth, portal, shellStyle }) {
                 // right column; the phone follows the flip tick into its
                 // canvas tab (the same path an agent-driven flip takes).
                 if (deepLinkTarget?.canvas) {
-                    controller.dispatch({ type: "canvas/flip", sessionId: initialSessionId });
+                    controller.dispatch({
+                        type: "canvas/flip",
+                        sessionId: initialSessionId,
+                        // Undefined/invalid falls back to slot 1 inside the
+                        // reducer, which is the behavior every link had before
+                        // this value was read at all.
+                        slot: deepLinkTarget?.slot ?? undefined,
+                    });
                     if (deepLinkTarget?.max) {
                         controller.dispatch({ type: "ui/canvasMaximized", on: true });
                     }
@@ -694,25 +683,42 @@ function PortalWorkspace({ auth, portal, shellStyle }) {
         };
     }, [controller, deepLinkTarget, initialSessionId, transport]);
 
-    return React.createElement("div", { className: "portal-app-shell", style: shellStyle },
+    return React.createElement("div", { className: `portal-app-shell${chromeHidden ? " is-chromeless" : ""}`, style: shellStyle },
+        // The dev-auth banner survives chrome hiding on purpose: it warns that
+        // the deployment is running an auth mode with no real identity behind
+        // it, and a cosmetic display option is not a reason to suppress a
+        // security notice.
         auth.provider === "dev"
             ? React.createElement("div", { className: "portal-dev-banner is-fixed" },
                 `${auth.config?.banner || "DEV AUTH — not for production"} · signed in as ${auth.account?.name || "?"}`)
             : null,
-        React.createElement(PortalHeader, {
-            account: auth.account,
-            authEnabled: auth.authEnabled,
-            isAdmin: auth.authorization?.role === "admin",
-            branding: portal?.branding,
-            onSignOut: auth.signOut,
-            versionLabel: PILOTSWARM_PORTAL_VERSION_LABEL,
-            statusText,
-            themeIcon,
-        }),
-        React.createElement(PortalMobileStatus, {
-            statusText: mobileStatusText,
-            onDismiss: () => setDismissedStatus(statusText),
-        }),
+        chromeHidden
+            ? React.createElement(PortalChromelessStrip, {
+                branding: portal?.branding,
+                onShowChrome: () => {
+                    setChromeHidden(false);
+                    // Keep the address bar honest: a reload, or the URL copied
+                    // out of the bar and passed on, must reproduce the view the
+                    // person is actually looking at — not the one they left.
+                    writeShowChromeParam(true);
+                },
+            })
+            : React.createElement(PortalHeader, {
+                account: auth.account,
+                authEnabled: auth.authEnabled,
+                isAdmin: auth.authorization?.role === "admin",
+                branding: portal?.branding,
+                onSignOut: auth.signOut,
+                versionLabel: PILOTSWARM_PORTAL_VERSION_LABEL,
+                statusText,
+                themeIcon,
+            }),
+        chromeHidden
+            ? null
+            : React.createElement(PortalMobileStatus, {
+                statusText: mobileStatusText,
+                onDismiss: () => setDismissedStatus(statusText),
+            }),
         React.createElement("main", { className: "portal-main" },
             React.createElement(PilotSwarmWebApp, { controller })),
     );

--- a/packages/app/web/src/App.jsx
+++ b/packages/app/web/src/App.jsx
@@ -700,19 +700,28 @@ function PortalWorkspace({ auth, portal, shellStyle }) {
                     // Keep the address bar honest: a reload, or the URL copied
                     // out of the bar and passed on, must reproduce the view the
                     // person is actually looking at — not the one they left.
-                    writeShowChromeParam(true);
+                    // Redirect sign-in returns to a bare URL, so hand the
+                    // consumed target back to the writer to restore the link's
+                    // session/view/slot fields as well as the chrome flag.
+                    writeShowChromeParam(true, deepLinkTarget);
                 },
             })
-            : React.createElement(PortalHeader, {
-                account: auth.account,
-                authEnabled: auth.authEnabled,
-                isAdmin: auth.authorization?.role === "admin",
-                branding: portal?.branding,
-                onSignOut: auth.signOut,
-                versionLabel: PILOTSWARM_PORTAL_VERSION_LABEL,
-                statusText,
-                themeIcon,
-            }),
+            : null,
+        // Keep the real header mounted while chromeless. The desktop toolbar
+        // discovers its portal target only after mount; removing the target on
+        // a chromeless landing made "Show chrome" restore an empty header and
+        // leave the toolbar stranded as a second inline row. CSS removes this
+        // mounted header from layout, focus order and the accessibility tree.
+        React.createElement(PortalHeader, {
+            account: auth.account,
+            authEnabled: auth.authEnabled,
+            isAdmin: auth.authorization?.role === "admin",
+            branding: portal?.branding,
+            onSignOut: auth.signOut,
+            versionLabel: PILOTSWARM_PORTAL_VERSION_LABEL,
+            statusText,
+            themeIcon,
+        }),
         chromeHidden
             ? null
             : React.createElement(PortalMobileStatus, {

--- a/packages/app/web/src/index.css
+++ b/packages/app/web/src/index.css
@@ -8304,6 +8304,13 @@ body.ps-dragging-sessions .ps-session-list-button.is-insert-before {
   outline-offset: 2px;
 }
 
+/* The header stays mounted so the desktop toolbar always has a stable portal
+   target. `display:none` makes the hidden header leave layout, tab order and
+   the accessibility tree while preserving that target for the restore. */
+.portal-app-shell.is-chromeless > .portal-header {
+  display: none;
+}
+
 /* Edge to edge: the workspace padding exists to sit the panes off the header,
    and with the header gone it only shrinks the canvas. */
 .portal-app-shell.is-chromeless > .portal-main {
@@ -9161,5 +9168,4 @@ textarea.ps-link-input {
   white-space: nowrap;
   text-align: right;
 }
-
 

--- a/packages/app/web/src/index.css
+++ b/packages/app/web/src/index.css
@@ -8180,6 +8180,23 @@ body.ps-dragging-sessions .ps-session-list-button.is-insert-before {
 
 .ps-canvas-share-actions { display: flex; gap: 8px; margin-top: 8px; }
 
+/* The "Hide page chrome" opt-in. A checkbox row rather than a select: it is a
+   property of the LINK being copied, not of the canvas, so it sits with the
+   link box and above the access policy it must not be confused with. */
+.ps-canvas-share-check {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+  font-size: 0.84rem;
+  cursor: pointer;
+}
+
+.ps-canvas-share-check input {
+  flex: none;
+  cursor: pointer;
+}
+
 /* Tab panels share ONE grid cell, so the container is always as tall as the
    taller panel and switching tabs never resizes the dialog. The inactive
    panel keeps its space (visibility, not display) — which is the whole
@@ -8235,6 +8252,83 @@ body.ps-dragging-sessions .ps-session-list-button.is-insert-before {
   text-align: center;
   gap: 6px;
   color: var(--ps-muted);
+}
+
+/* ── show_chrome=false: the header's stand-in ───────────────────────────────
+   A signed-in viewer who followed a "hide page chrome" link. Deliberately the
+   same visual weight as the public share strip above — one muted line — so the
+   two chromeless landings feel like one idea. */
+.portal-chromeless-strip {
+  flex: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  color: var(--ps-muted);
+  border-bottom: 1px solid var(--ps-border);
+}
+
+.portal-chromeless-strip-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Recessed on purpose: this mode exists so nothing competes with the canvas,
+   so the way back is almost invisible until it is looked for. It is still a
+   real button — focus-visible restores it in full for keyboard users, who
+   otherwise could not tell they had landed on it. */
+.portal-chromeless-strip-restore {
+  flex: none;
+  border: 0;
+  background: none;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  opacity: 0.18;
+  transition: opacity 120ms ease;
+}
+
+.portal-chromeless-strip-restore:hover {
+  opacity: 1;
+}
+
+.portal-chromeless-strip-restore:focus-visible {
+  opacity: 1;
+  outline: 2px solid var(--ps-accent);
+  outline-offset: 2px;
+}
+
+/* Edge to edge: the workspace padding exists to sit the panes off the header,
+   and with the header gone it only shrinks the canvas. */
+.portal-app-shell.is-chromeless > .portal-main {
+  padding: 0;
+}
+
+/* The workspace toolbar is chrome too, and it is NOT covered by a maximized
+   canvas: the canvas layer positions against .ps-workspace-grid, which starts
+   below this bar. Without this rule "hide page chrome" left a full row of
+   New-session / Filter / Diagnostics / Budget / Admin / Theme sitting above the
+   canvas — the workspace, still visibly there.
+
+   The whole bar goes, including the canvas zoom/zen group that shares it. That
+   group is genuinely canvas-related, but leaving it behind would strand a
+   floating cluster of buttons over an otherwise bare page, which reads as a
+   rendering fault rather than a deliberate mode. Everything returns together
+   via "Show chrome".
+
+   display:none rather than opacity/visibility on purpose: hidden chrome must
+   also leave the tab order and the accessibility tree, or a keyboard user
+   tabs through a dozen invisible workspace controls. The slot elements
+   PortalHeader portals into stay in the DOM, so nothing that looks them up
+   starts spinning. */
+.portal-app-shell.is-chromeless .ps-toolbar {
+  display: none;
 }
 
 

--- a/packages/app/web/src/lib/deep-link.js
+++ b/packages/app/web/src/lib/deep-link.js
@@ -108,9 +108,11 @@ export function parseStashedDeepLinkTarget(raw) {    if (!raw) return null;
  * copied the URL out of the bar and sent it on — would be thrown back into a
  * chromeless view they had explicitly left. The parameter is written as an
  * explicit `true` rather than deleted so the URL keeps saying, out loud, which
- * mode it is in.
+ * mode it is in. Redirect sign-in returns to the bare redirect URI; when that
+ * happened, `target` restores the consumed session target before the rewrite
+ * so refresh/copy still points at the canvas the viewer is looking at.
  */
-export function writeShowChromeParam(show) {
+export function writeShowChromeParam(show, target = null) {
     if (typeof window === "undefined") return null;
     // A browser too old for replaceState, or a test double without one, simply
     // keeps the stale parameter: the on-screen toggle still works, and this is
@@ -118,6 +120,24 @@ export function writeShowChromeParam(show) {
     if (typeof window.history?.replaceState !== "function" || !window.location?.href) return null;
     try {
         const url = new URL(window.location.href);
+        const currentSessionId = (url.searchParams.get("session") || "").trim();
+        const restoredSessionId = String(target?.sessionId || "").trim();
+        if (!currentSessionId && restoredSessionId) {
+            url.searchParams.set("session", restoredSessionId);
+
+            if (target?.artifact) url.searchParams.set("artifact", String(target.artifact));
+            else url.searchParams.delete("artifact");
+
+            if (target?.canvas) url.searchParams.set("view", "canvas");
+            else if (target?.fullscreen) url.searchParams.set("view", "full");
+            else url.searchParams.delete("view");
+
+            if (Number.isInteger(target?.slot)) url.searchParams.set("slot", String(target.slot));
+            else url.searchParams.delete("slot");
+
+            if (target?.max) url.searchParams.set("max", "1");
+            else url.searchParams.delete("max");
+        }
         url.searchParams.set("show_chrome", show ? "true" : "false");
         window.history.replaceState(window.history.state ?? null, "", `${url.pathname}${url.search}${url.hash}`);
         return url.search;

--- a/packages/app/web/src/lib/deep-link.js
+++ b/packages/app/web/src/lib/deep-link.js
@@ -1,0 +1,127 @@
+// Portal deep-link targets: the URL contract, and the stash that carries it
+// across a redirect sign-in.
+//
+// Split out of App.jsx so these can be tested for real. App.jsx pulls in React,
+// MSAL, the UI packages and a stylesheet, so a test that imported it could only
+// ever regex the source; these functions are pure enough to drive directly.
+
+// Deep links stash ?session= in sessionStorage before sign-in because the
+// redirect-based sign-in path (mobile Entra loginRedirect) returns to the bare
+// redirectUri and drops the query string; popup/dev sign-ins never navigate,
+// so the URL param survives those on its own.
+export const DEEP_LINK_SESSION_STORAGE_KEY = "pilotswarm.portal.deepLinkSession";
+
+/**
+ * A canvas slot from a URL or a stash, or null when the link named none.
+ *
+ * Guarding the empty cases first is the whole job: `Number(null)` and
+ * `Number("")` are both 0, and 0 is an integer, so a bare `Number.isInteger`
+ * check turns "no slot" into "slot 0" — which then clamps to 1 and looks
+ * correct right up until someone links to slot 2.
+ *
+ * Anything that survives is passed through UN-clamped: `canvas/flip` already
+ * bounds it to 1..5 and falls back to slot 1, and a second clamp here could
+ * only ever disagree with that one.
+ */
+function parseSlot(raw) {
+    if (raw === null || raw === undefined) return null;
+    const text = String(raw).trim();
+    if (!text) return null;
+    const value = Number(text);
+    return Number.isInteger(value) ? value : null;
+}
+
+/**
+ * A deep-link target: `?session=<id>[&artifact=<filename>][&view=full|canvas][&show_chrome=false]`.
+ *
+ * The artifact form is what the agent's show_artifact tool hands back and what
+ * the Files "copy link" button produces, so a link pasted into chat, mailed to
+ * a colleague, or opened in a new tab all land on the same preview.
+ * `view=canvas` opens the session with its canvas up — the shareable "look at
+ * the dashboard" link. `show_chrome=false` additionally strips the portal
+ * header so the canvas is the whole page.
+ */
+export function readDeepLinkTargetFromUrl() {
+    if (typeof window === "undefined" || !window.location) return null;
+    const params = new URLSearchParams(window.location.search);
+    const sessionId = (params.get("session") || "").trim();
+    if (!sessionId) return null;
+    const artifact = (params.get("artifact") || "").trim();
+    const view = (params.get("view") || "").trim().toLowerCase();
+    return {
+        sessionId,
+        artifact: artifact || null,
+        fullscreen: view === "full",
+        canvas: view === "canvas",
+        // ?max=1 with view=canvas: arrive with the canvas COVERING the
+        // workspace — the share-link landing experience.
+        max: params.get("max") === "1",
+        // Which canvas the link points at. The share dialog has always
+        // emitted this; nothing read it, so a link to a session's second
+        // canvas quietly opened its first.
+        slot: parseSlot(params.get("slot")),
+        // ?show_chrome=false: land with the portal header suppressed, so the
+        // canvas is the whole page. Only the explicit string "false" opts in —
+        // absence, "true", or anything else keeps the chrome, which is what
+        // makes every link written before this parameter existed behave
+        // exactly as it always did.
+        hideChrome: params.get("show_chrome") === "false",
+    };
+}
+
+export function parseStashedDeepLinkTarget(raw) {    if (!raw) return null;
+    // Older builds stashed a bare session id string. A stash written before an
+    // upgrade can still be sitting in this tab when the new bundle loads.
+    if (!raw.startsWith("{")) return { sessionId: raw, artifact: null, fullscreen: false };
+    try {
+        const parsed = JSON.parse(raw);
+        const sessionId = String(parsed?.sessionId || "").trim();
+        if (!sessionId) return null;
+        return {
+            sessionId,
+            artifact: parsed?.artifact ? String(parsed.artifact) : null,
+            canvas: Boolean(parsed?.canvas),
+            fullscreen: Boolean(parsed?.fullscreen),
+            max: Boolean(parsed?.max),
+            slot: parseSlot(parsed?.slot),
+            // Load-bearing for the common case: a recipient who is NOT already
+            // signed in gets stashed here and restored after the redirect, so
+            // dropping this field would lose the chromeless mode for exactly
+            // the audience a share link is written for.
+            hideChrome: Boolean(parsed?.hideChrome),
+        };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Rewrite `show_chrome` in the address bar to match what is actually on screen.
+ *
+ * Toggling chrome back on is a change of VIEW, not a navigation, so this
+ * replaces the current entry rather than pushing one: a Back button that
+ * undoes a cosmetic toggle, and a history stack that fills up with them, is
+ * not what anyone means by Back.
+ *
+ * The point is refresh consistency. Without this, a viewer who followed a
+ * `show_chrome=false` link, clicked "Show chrome", and then reloaded — or
+ * copied the URL out of the bar and sent it on — would be thrown back into a
+ * chromeless view they had explicitly left. The parameter is written as an
+ * explicit `true` rather than deleted so the URL keeps saying, out loud, which
+ * mode it is in.
+ */
+export function writeShowChromeParam(show) {
+    if (typeof window === "undefined") return null;
+    // A browser too old for replaceState, or a test double without one, simply
+    // keeps the stale parameter: the on-screen toggle still works, and this is
+    // cosmetic bookkeeping, never a precondition for it.
+    if (typeof window.history?.replaceState !== "function" || !window.location?.href) return null;
+    try {
+        const url = new URL(window.location.href);
+        url.searchParams.set("show_chrome", show ? "true" : "false");
+        window.history.replaceState(window.history.state ?? null, "", `${url.pathname}${url.search}${url.hash}`);
+        return url.search;
+    } catch {
+        return null;
+    }
+}

--- a/packages/app/web/test/canvas-share-chrome.test.mjs
+++ b/packages/app/web/test/canvas-share-chrome.test.mjs
@@ -37,7 +37,7 @@ function targetFor(search) {
 }
 
 /** Drive the URL rewrite against a fake history, returning what it replaced. */
-function rewriteFrom(href, show, { history } = {}) {
+function rewriteFrom(href, show, { history, target } = {}) {
     const previous = globalThis.window;
     const calls = [];
     globalThis.window = {
@@ -48,7 +48,7 @@ function rewriteFrom(href, show, { history } = {}) {
         },
     };
     try {
-        const returned = writeShowChromeParam(show);
+        const returned = writeShowChromeParam(show, target);
         return { calls, returned };
     } finally {
         if (previous === undefined) delete globalThis.window;
@@ -163,10 +163,14 @@ test("the share dialog appends show_chrome only when the box is checked", () => 
 
 // ─── 4. The chromeless render path ──────────────────────────────────────────
 
-test("chrome hiding swaps the header for the strip and nothing else", () => {
+test("chrome hiding shows the strip while keeping the real header mounted", () => {
     const workspace = APP.slice(APP.indexOf("function PortalWorkspace"));
     assert.match(workspace, /chromeHidden\s*\?\s*React\.createElement\(PortalChromelessStrip/,
-        "the strip stands in for PortalHeader");
+        "the strip is shown only in chromeless mode");
+    assert.match(workspace, /\}\)\s*:\s*null,\s*\/\/ Keep the real header mounted[\s\S]{0,500}?React\.createElement\(PortalHeader/,
+        "the real header and its toolbar portal target stay mounted behind the strip");
+    assert.match(CSS, /\.portal-app-shell\.is-chromeless > \.portal-header \{\s*display: none;/,
+        "the mounted header leaves layout, focus order, and the accessibility tree");
     assert.match(workspace, /useState\(\(\) => Boolean\(deepLinkTarget\?\.hideChrome\)\)/,
         "seeded from the deep link, but stateful so it can be restored");
     assert.match(workspace, /onShowChrome: \(\) => \{[\s\S]{0,400}?setChromeHidden\(false\)/,
@@ -265,6 +269,25 @@ test("a URL with no show_chrome gains an explicit one", () => {
     assert.match(calls[0].url, /show_chrome=true/);
 });
 
+test("a redirect-restored target reconstructs the complete address-bar link", () => {
+    const target = parseStashedDeepLinkTarget(JSON.stringify({
+        sessionId: "session after sign-in",
+        canvas: true,
+        fullscreen: false,
+        max: true,
+        slot: 3,
+        hideChrome: true,
+    }));
+    const { calls } = rewriteFrom("http://portal.example/", true, { target });
+    const params = new URLSearchParams(calls[0].url.slice(calls[0].url.indexOf("?")));
+
+    assert.equal(params.get("session"), "session after sign-in");
+    assert.equal(params.get("view"), "canvas");
+    assert.equal(params.get("slot"), "3");
+    assert.equal(params.get("max"), "1");
+    assert.equal(params.get("show_chrome"), "true");
+});
+
 test("a browser without replaceState is a no-op, not a crash", () => {
     // The on-screen toggle is what matters; the URL is bookkeeping.
     const { calls, returned } = rewriteFrom("http://portal.example/?show_chrome=false", true, { history: null });
@@ -274,8 +297,17 @@ test("a browser without replaceState is a no-op, not a crash", () => {
 
 test("the strip's button is what triggers the rewrite", () => {
     const workspace = APP.slice(APP.indexOf("function PortalWorkspace"));
-    assert.match(workspace, /onShowChrome: \(\) => \{[\s\S]{0,400}?writeShowChromeParam\(true\)/,
-        "clicking Show chrome updates the URL as well as the state");
+    assert.match(workspace, /onShowChrome: \(\) => \{[\s\S]{0,800}?writeShowChromeParam\(true, deepLinkTarget\)/,
+        "clicking Show chrome updates the URL and restores the consumed redirect target");
+});
+
+test("the canvas share dialog escapes pane stacking contexts", () => {
+    const dialog = WEB_APP.slice(
+        WEB_APP.indexOf("function CanvasShareDialog"),
+        WEB_APP.indexOf("function CanvasSlotControls"),
+    );
+    assert.match(dialog, /createPortal\(overlay, document\.body\)/,
+        "the viewport overlay is rooted above z-indexed pane dividers");
 });
 
 // ─── 5. The branding chain the strip label depends on ───────────────────────

--- a/packages/app/web/test/canvas-share-chrome.test.mjs
+++ b/packages/app/web/test/canvas-share-chrome.test.mjs
@@ -1,0 +1,310 @@
+// The "Hide page chrome" share option: `show_chrome=false`.
+//
+// Three things have to hold for the feature to work, and each fails silently in
+// a different way, so each is pinned here:
+//   1. the parameter is read, and ONLY the explicit "false" opts in;
+//   2. it survives the sign-in stash — otherwise it works for the sender and
+//      not for the recipient, who is the entire audience for a share link;
+//   3. the strip names the deployment through the same helper the real header
+//      uses, so a rebranded portal cannot end up calling itself "PilotSwarm".
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import {
+    DEEP_LINK_SESSION_STORAGE_KEY,
+    parseStashedDeepLinkTarget,
+    readDeepLinkTargetFromUrl,
+    writeShowChromeParam,
+} from "../src/lib/deep-link.js";
+
+const APP = readFileSync(fileURLToPath(new URL("../src/App.jsx", import.meta.url)), "utf8");
+const WEB_APP = readFileSync(fileURLToPath(new URL(
+    "../../ui/react/src/web-app.js", import.meta.url)), "utf8");
+const CSS = readFileSync(fileURLToPath(new URL("../src/index.css", import.meta.url)), "utf8");
+
+/** Drive the real parser against a URL by standing in for `window`. */
+function targetFor(search) {
+    const previous = globalThis.window;
+    globalThis.window = { location: { search } };
+    try {
+        return readDeepLinkTargetFromUrl();
+    } finally {
+        if (previous === undefined) delete globalThis.window;
+        else globalThis.window = previous;
+    }
+}
+
+/** Drive the URL rewrite against a fake history, returning what it replaced. */
+function rewriteFrom(href, show, { history } = {}) {
+    const previous = globalThis.window;
+    const calls = [];
+    globalThis.window = {
+        location: { href },
+        history: history === null ? {} : {
+            state: { some: "state" },
+            replaceState: (state, title, url) => calls.push({ state, title, url }),
+        },
+    };
+    try {
+        const returned = writeShowChromeParam(show);
+        return { calls, returned };
+    } finally {
+        if (previous === undefined) delete globalThis.window;
+        else globalThis.window = previous;
+    }
+}
+
+// ─── 1. Reading the parameter ───────────────────────────────────────────────
+
+test("only the explicit show_chrome=false hides the chrome", () => {
+    assert.equal(targetFor("?session=s1&show_chrome=false").hideChrome, true);
+
+    // Everything else keeps the header. The absent case is the one that
+    // matters most: every link written before this parameter existed must go on
+    // behaving exactly as it did, which is also what makes the checkbox's
+    // "default unchecked" real.
+    assert.equal(targetFor("?session=s1").hideChrome, false, "absent → chrome stays");
+    assert.equal(targetFor("?session=s1&show_chrome=true").hideChrome, false, "true → chrome stays");
+    assert.equal(targetFor("?session=s1&show_chrome=0").hideChrome, false, "0 is not false");
+    assert.equal(targetFor("?session=s1&show_chrome=False").hideChrome, false, "not case-folded");
+    assert.equal(targetFor("?session=s1&show_chrome=").hideChrome, false, "empty → chrome stays");
+});
+
+test("show_chrome rides alongside the rest of the canvas share link", () => {
+    // The exact shape CanvasShareDialog emits with the box checked.
+    const target = targetFor("?session=abc&view=canvas&slot=1&max=1&show_chrome=false");
+    assert.deepEqual(target, {
+        sessionId: "abc",
+        artifact: null,
+        fullscreen: false,
+        canvas: true,
+        max: true,
+        slot: 1,
+        hideChrome: true,
+    });
+});
+
+// ─── 1b. The slot the link always carried but nobody read ───────────────────
+// The dialog has always emitted &slot=<n>; the parser ignored it, so a link to
+// a session's SECOND canvas opened its first. That is worse with show_chrome,
+// where the wrong canvas fills the whole page with no chrome to correct it by.
+
+test("the link's slot is read, so a second canvas opens as itself", () => {
+    assert.equal(targetFor("?session=s1&view=canvas&slot=2&max=1").slot, 2);
+    assert.equal(targetFor("?session=s1&view=canvas&slot=5").slot, 5);
+});
+
+test("a missing or unparseable slot stays null and defers to the reducer", () => {
+    // Deliberately not normalized here: canvas/flip already clamps to 1..5 and
+    // falls back to slot 1, so these land exactly where they always did rather
+    // than growing a second, disagreeing clamp.
+    assert.equal(targetFor("?session=s1&view=canvas").slot, null, "absent");
+    assert.equal(targetFor("?session=s1&view=canvas&slot=").slot, null, "empty");
+    assert.equal(targetFor("?session=s1&view=canvas&slot=abc").slot, null, "not a number");
+    assert.equal(targetFor("?session=s1&view=canvas&slot=1.5").slot, null, "not an integer");
+});
+
+test("the slot survives the sign-in stash too", () => {
+    const stashed = JSON.stringify(targetFor("?session=s1&view=canvas&slot=3&show_chrome=false"));
+    const restored = parseStashedDeepLinkTarget(stashed);
+    assert.equal(restored.slot, 3);
+    assert.equal(restored.hideChrome, true);
+});
+
+test("the canvas flip is handed the link's slot", () => {
+    const workspace = APP.slice(APP.indexOf("function PortalWorkspace"));
+    assert.match(workspace, /type: "canvas\/flip",[\s\S]{0,400}?slot: deepLinkTarget\?\.slot/,
+        "the parsed slot actually reaches the dispatch");
+});
+
+test("show_chrome alone does not conjure a target", () => {
+    assert.equal(targetFor("?show_chrome=false"), null, "no session id, no deep link");
+});
+
+// ─── 2. Surviving the redirect sign-in ──────────────────────────────────────
+
+test("hideChrome round-trips through the sign-in stash", () => {
+    // A signed-out recipient is stashed to sessionStorage and restored after
+    // the redirect. If this field were dropped the mode would work only for
+    // people who were already signed in.
+    const stashed = JSON.stringify(targetFor("?session=s1&view=canvas&max=1&show_chrome=false"));
+    const restored = parseStashedDeepLinkTarget(stashed);
+    assert.equal(restored.hideChrome, true);
+    assert.equal(restored.canvas, true);
+    assert.equal(restored.sessionId, "s1");
+});
+
+test("a stash without the field restores as chrome-visible, never undefined", () => {
+    const restored = parseStashedDeepLinkTarget(JSON.stringify({ sessionId: "s1" }));
+    assert.equal(restored.hideChrome, false);
+
+    // The pre-upgrade bare-string stash still resolves rather than throwing.
+    assert.equal(parseStashedDeepLinkTarget("s1").sessionId, "s1");
+    assert.equal(parseStashedDeepLinkTarget(""), null);
+    assert.equal(parseStashedDeepLinkTarget("{not json"), null);
+});
+
+test("the stash key is unchanged, so an in-flight sign-in still lands", () => {
+    assert.equal(DEEP_LINK_SESSION_STORAGE_KEY, "pilotswarm.portal.deepLinkSession");
+});
+
+// ─── 3. The dialog emits it only when asked ─────────────────────────────────
+
+test("the share dialog appends show_chrome only when the box is checked", () => {
+    const link = WEB_APP.slice(WEB_APP.indexOf("const sessionLink ="));
+    const line = link.slice(0, link.indexOf("\n"));
+    assert.match(line, /hideChrome \? "&show_chrome=false" : ""/,
+        "the parameter is conditional on the checkbox, not always present");
+    assert.match(WEB_APP, /const \[hideChrome, setHideChrome\] = React\.useState\(false\)/,
+        "default unchecked");
+});
+
+// ─── 4. The chromeless render path ──────────────────────────────────────────
+
+test("chrome hiding swaps the header for the strip and nothing else", () => {
+    const workspace = APP.slice(APP.indexOf("function PortalWorkspace"));
+    assert.match(workspace, /chromeHidden\s*\?\s*React\.createElement\(PortalChromelessStrip/,
+        "the strip stands in for PortalHeader");
+    assert.match(workspace, /useState\(\(\) => Boolean\(deepLinkTarget\?\.hideChrome\)\)/,
+        "seeded from the deep link, but stateful so it can be restored");
+    assert.match(workspace, /onShowChrome: \(\) => \{[\s\S]{0,400}?setChromeHidden\(false\)/,
+        "the restore control actually restores");
+
+    // The dev-auth banner is a security notice, not decoration: a cosmetic
+    // display option must not be able to suppress it.
+    const banner = workspace.indexOf("portal-dev-banner");
+    const strip = workspace.indexOf("PortalChromelessStrip");
+    assert.ok(banner > 0 && banner < strip,
+        "the dev banner is rendered before, and independently of, the chrome switch");
+});
+
+test("the strip names the deployment with the same helper the header uses", () => {
+    // Not a hard-coded "PilotSwarm": a portal whose plugin sets portal.title
+    // (Waldemort does) must say its own name in the strip too.
+    const stripFn = APP.slice(APP.indexOf("function PortalChromelessStrip"));
+    assert.match(stripFn.slice(0, stripFn.indexOf("function PortalWorkspace")),
+        /getWorkspaceTitle\(branding\)/,
+        "the strip label goes through getWorkspaceTitle");
+    assert.match(APP, /branding\?\.title \|\| "PilotSwarm"/,
+        "which falls back to PilotSwarm only when branding names nothing");
+    assert.match(APP, /React\.createElement\(PortalChromelessStrip, \{\s*branding: portal\?\.branding/,
+        "and it is handed the deployment's branding");
+});
+
+test("the restore control is recessed but still keyboard reachable", () => {
+    const rule = CSS.slice(CSS.indexOf(".portal-chromeless-strip-restore {"));
+    const block = rule.slice(0, rule.indexOf("}"));
+    assert.match(block, /opacity: 0\.\d+/, "recessed at rest");
+    assert.match(CSS, /\.portal-chromeless-strip-restore:focus-visible \{[^}]*opacity: 1/,
+        "focus brings it back — otherwise a keyboard user lands on an invisible control");
+    assert.match(CSS, /\.portal-chromeless-strip-restore:focus-visible \{[^}]*outline:/,
+        "with a real focus ring");
+});
+
+test("hiding chrome also hides the workspace toolbar", () => {
+    // A maximized canvas covers .ps-workspace-grid, which begins BELOW this
+    // bar — so without an explicit rule the toolbar survived "hide page chrome"
+    // and the workspace was still plainly on screen.
+    assert.match(CSS, /\.portal-app-shell\.is-chromeless \.ps-toolbar \{\s*display: none;/,
+        "the toolbar is hidden in chromeless mode");
+    // display:none, not opacity: hidden chrome must leave the tab order too.
+    const rule = CSS.slice(CSS.indexOf(".portal-app-shell.is-chromeless .ps-toolbar {"));
+    assert.doesNotMatch(rule.slice(0, rule.indexOf("}")), /opacity|visibility/,
+        "not merely painted out — it must leave the a11y tree and tab order");
+});
+
+test("the workspace padding collapses so the canvas runs edge to edge", () => {
+    assert.match(CSS, /\.portal-app-shell\.is-chromeless > \.portal-main \{\s*padding: 0;/);
+});
+
+// ─── 6. The address bar follows the view ────────────────────────────────────
+// Clicking "Show chrome" has to flip the parameter, or a reload — or the URL
+// copied out of the bar and passed on — throws the viewer back into the
+// chromeless view they just left.
+
+test("showing chrome flips show_chrome=false to true in place", () => {
+    const { calls, returned } = rewriteFrom(
+        "http://portal.example/?session=s1&view=canvas&slot=1&max=1&show_chrome=false", true);
+    assert.equal(calls.length, 1);
+    assert.match(calls[0].url, /show_chrome=true/);
+    assert.doesNotMatch(calls[0].url, /show_chrome=false/);
+    assert.match(returned, /show_chrome=true/);
+});
+
+test("the rest of the link is left exactly as it was", () => {
+    const { calls } = rewriteFrom(
+        "http://portal.example/?session=s1&view=canvas&slot=2&max=1&show_chrome=false", true);
+    const params = new URLSearchParams(calls[0].url.slice(calls[0].url.indexOf("?")));
+    assert.equal(params.get("session"), "s1");
+    assert.equal(params.get("view"), "canvas");
+    assert.equal(params.get("slot"), "2", "the slot must survive — it decides WHICH canvas");
+    assert.equal(params.get("max"), "1");
+    assert.equal(params.get("show_chrome"), "true");
+});
+
+test("it replaces the history entry rather than pushing one", () => {
+    // A cosmetic toggle must not put itself between the viewer and Back, and
+    // must not accumulate entries if they toggle repeatedly.
+    const { calls } = rewriteFrom("http://portal.example/?show_chrome=false", true);
+    assert.deepEqual(calls[0].state, { some: "state" }, "the existing history state is preserved");
+});
+
+test("the path and hash survive, and the origin is not re-stated", () => {
+    const { calls } = rewriteFrom("http://portal.example/sub/path?show_chrome=false#frag", true);
+    assert.ok(calls[0].url.startsWith("/sub/path?"), `relative to the origin: ${calls[0].url}`);
+    assert.ok(calls[0].url.endsWith("#frag"), `hash kept: ${calls[0].url}`);
+});
+
+test("a URL with no show_chrome gains an explicit one", () => {
+    // Reached from a stash-restored load, where the redirect dropped the query
+    // string entirely. Saying "true" out loud beats an absence that happens to
+    // mean the same thing.
+    const { calls } = rewriteFrom("http://portal.example/", true);
+    assert.match(calls[0].url, /show_chrome=true/);
+});
+
+test("a browser without replaceState is a no-op, not a crash", () => {
+    // The on-screen toggle is what matters; the URL is bookkeeping.
+    const { calls, returned } = rewriteFrom("http://portal.example/?show_chrome=false", true, { history: null });
+    assert.equal(calls.length, 0);
+    assert.equal(returned, null);
+});
+
+test("the strip's button is what triggers the rewrite", () => {
+    const workspace = APP.slice(APP.indexOf("function PortalWorkspace"));
+    assert.match(workspace, /onShowChrome: \(\) => \{[\s\S]{0,400}?writeShowChromeParam\(true\)/,
+        "clicking Show chrome updates the URL as well as the state");
+});
+
+// ─── 5. The branding chain the strip label depends on ───────────────────────
+// Driven through the real resolver against a real plugin.json shape, so a
+// change to how portal.title is resolved fails here rather than silently
+// renaming a rebranded deployment's canvas strip back to "PilotSwarm".
+
+test("a plugin's portal.title becomes the name the strip shows", async () => {
+    const { mkdtempSync, writeFileSync, rmSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { resolvePortalConfigFromPluginDirs } = await import(
+        "../../tui/src/plugin-config.js");
+
+    // The shape Waldemort ships in its plugin/plugin.json.
+    const dir = mkdtempSync(join(tmpdir(), "ps-branding-"));
+    try {
+        writeFileSync(join(dir, "plugin.json"), JSON.stringify({
+            name: "waldemort",
+            portal: { title: "Waldemort", pageTitle: "Waldemort — Postgres Stress Testing" },
+        }));
+        const branded = resolvePortalConfigFromPluginDirs([dir]);
+        assert.equal(branded?.branding?.title, "Waldemort");
+
+        // And with no plugin at all, the same chain yields the stock name, so
+        // the strip never renders an empty or undefined deployment label.
+        const plain = resolvePortalConfigFromPluginDirs([]);
+        assert.equal(plain?.branding?.title, "PilotSwarm");
+    } finally {
+        rmSync(dir, { recursive: true, force: true });
+    }
+});


### PR DESCRIPTION
## Motivation — telemetry report sharing

Supports the **telemetry report sharing use case**: a canvas is often a report or dashboard, and sharing one should show the *report*, not the workspace it happens to live in. The existing Session access link always opened the full portal — header, workspace toolbar, sessions and chat framing the canvas.

## What this adds

A **Hide page chrome** checkbox (off by default) in the canvas share dialog's Session access tab. Checked, the link carries `show_chrome=false` and lands on the canvas alone.

Such a link still goes through the **normal authenticated path** — sign-in plus the existing session visibility rules. That is the difference from the `canvasShare` token in the neighbouring tab, which bypasses auth entirely and is always read-only.

The mode is **presentation only**. It hides chrome; it does not make the canvas read-only, because a query parameter is not a permission — the recipient can simply delete it. What a viewer may change inside the app is still decided by the existing "Who can edit inside this app" policy, and the strip is worded so it never implies otherwise.

## Details

- The strip names the deployment through the same `getWorkspaceTitle` the header kicker uses, so a rebranded portal (Waldemort sets `portal.title`) cannot end up calling itself PilotSwarm.
- `hideChrome` round-trips through the sign-in stash. Without that the mode works for the sender but not for a signed-out recipient — the entire audience for a share link.
- The workspace toolbar is hidden too. The maximized canvas layer positions against `.ps-workspace-grid`, which begins *below* that bar, so `max=1` could never cover it. `display:none`, so it also leaves the tab order rather than just being painted out.
- **Show chrome** restores everything without a reload and rewrites the URL to `show_chrome=true` (`replaceState`, not push), so a refresh — or the URL copied out of the address bar — reproduces what is on screen. The control is deliberately recessed (~0.2 opacity, full on hover/`:focus-visible` with a focus ring) so it does not compete with canvas content.
- The dev-auth banner deliberately survives chrome hiding: it warns about an auth mode with no real identity behind it, and a cosmetic display option is not a reason to suppress a security notice.

## Drive-by fix

The share dialog has always emitted `&slot=<n>`, but nothing ever read it, so a link to a session's **second** canvas quietly opened its first. That is worse under `show_chrome=false`, where the wrong canvas fills the page with no chrome to notice by. `canvas/flip` already accepted and clamped a slot; the URL value simply never reached it.

## Testing

24 new tests in `packages/app/web/test/canvas-share-chrome.test.mjs`; suite is **118 tests, 0 failures**.

The pure deep-link parsers move to `src/lib/deep-link.js` so they can be driven directly — `App.jsx` pulls in React and MSAL and can only be regexed. Writing the slot test caught a real bug in the first attempt: `Number(null)` and `Number("")` are both `0`, and `0` is an integer, so "no slot" parsed as "slot 0"; now guarded in `parseSlot`.

Verified live against a local deployment: chromeless load, restore-without-reload, URL flip, refresh consistency, and no regression to the default link (header present, toolbar `display: grid`, link byte-identical).

## Parity

Portal-only by nature — the native TUI has no page header and no share URLs, so there is no corresponding surface to keep in sync.
